### PR TITLE
Add a function to get velocity cell id from velocity

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -752,6 +752,29 @@ class VlsvReader(object):
 
 
 
+   def get_velocity_cell_ids(self, vcellcoord):
+      ''' Returns velocity cell ids of given coordinate
+
+      Arguments:
+      :param vcellcoords: One 3d coordinate
+      :returns: Velocity cell id
+
+      .. seealso:: :func:`get_velocity_cell_coordinates`
+      '''
+      vmin = np.array([self.__vxmin, self.__vymin, self.__vzmin])
+      dv = np.array([self.__dvx, self.__dvy, self.__dvz])
+      block_index = np.floor((vcellcoord - vmin) / (4 * dv))
+      cell_index = np.floor(np.remainder(vcellcoord - vmin, 4*dv) / dv)
+      vcellid = int(block_index[0])
+      vcellid += int(block_index[1] * self.__vxblocks)
+      vcellid += int(block_index[2] * self.__vxblocks * self.__vyblocks)
+      vcellid *= 64
+      vcellid += int(cell_index[0])
+      vcellid += int(cell_index[1] * 4)
+      vcellid += int(cell_index[2] * 16)
+      return vcellid
+
+
    def get_velocity_cell_coordinates(self, vcellids):
       ''' Returns a given velocity cell's coordinates as a numpy array
 


### PR DESCRIPTION
Current limitation is that only one coordinate can be converted to an id at a time.

Tested with:
```
import pytools as pt
d = pt.vlsvfile.VlsvReader('../../vlasiator-testi2/bulk.0000054.vlsv') # from magnetospheric test
for c in range(100000):
  if d.get_velocity_cell_ids(d.get_velocity_cell_coordinates(c)[0]) != c:
    print c, d.get_velocity_cell_ids(d.get_velocity_cell_coordinates(c)[0])
    exit('fail')
```
which after about 10 s returned successfully.