### PR TITLE
Bugfixes 20170629

### DIFF
--- a/pyMayaVi/mayavigrid.py
+++ b/pyMayaVi/mayavigrid.py
@@ -128,6 +128,7 @@ class MayaviGrid(HasTraits):
       self.__maxs = []
       self.__cells = []
       self.__last_pick = []
+      self.__grid_figure = mayavi.mlab.gcf(engine=self.__engine)
       self.__structured_figures = []
       self.__unstructured_figures = []
       self.__thread = []
@@ -168,7 +169,7 @@ class MayaviGrid(HasTraits):
       y = [cell_coordinates[1]]
       z = [cell_coordinates[2]]
       s = [(dx+dy+dx)/3.0]
-      points = self.scene.mlab.points3d(x,y,z,s, scale_factor=3)
+      points = self.scene.mlab.points3d(x,y,z,s, scale_factor=3, figure=self.__grid_figure, reset_zoom=False )
 
 
    def __add_normal_labels( self, point1, point2 ):
@@ -622,6 +623,8 @@ class MayaviGrid(HasTraits):
       print scalars[0]
       # Configure traits
       self.configure_traits()
+      
+      self.__grid_figure = mayavi.mlab.gcf(engine=self.__engine)
 
       # Note: This is not working properly -- it seemingly works out at first but it eventually causes segmentation faults in some places
       #self.__thread = threading.Thread(target=self.configure_traits, args=())

--- a/pyMayaVi/mayavigrid.py
+++ b/pyMayaVi/mayavigrid.py
@@ -110,7 +110,7 @@ class MayaviGrid(HasTraits):
                 resizable=True,
             )
 
-   def __init__(self, vlsvReader, variable, operator="pass", threaded=True, **traits):
+   def __init__(self, vlsvReader, variable, operator="pass", threaded=False, **traits):
       ''' Initializes the class and loads the mayavi grid
 
           :param vlsvReader:        Some vlsv reader with a file open
@@ -208,7 +208,7 @@ class MayaviGrid(HasTraits):
       self.__add_label( cellid2 )
 
 
-   def __load_grid( self, variable, operator="pass", threaded=True ):
+   def __load_grid( self, variable, operator="pass", threaded=False ):
       ''' Creates a grid and inputs scalar variables from a vlsv file
           :param variable:        Name of the variable to plot
           :param operator:        Operator for the variable

--- a/pyMayaVi/mayavigrid.py
+++ b/pyMayaVi/mayavigrid.py
@@ -277,6 +277,9 @@ class MayaviGrid(HasTraits):
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
          pick_cell_coordinates = self.vlsvReader.get_cell_coordinates(cellid)
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Find the nearest:
          from operator import itemgetter
          norms = np.sum((cell_candidate_coordinates - pick_cell_coordinates)**2, axis=-1)**(1./2)
@@ -296,6 +299,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
@@ -315,6 +321,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
@@ -338,6 +347,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
@@ -419,6 +431,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
@@ -439,6 +454,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:
@@ -487,6 +505,9 @@ class MayaviGrid(HasTraits):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
          cell_candidates = self.vlsvReader.read(mesh = "SpatialGrid", tag = "CELLSWITHBLOCKS")
+         if len(cell_candidates) == 0:
+            print "No velocity distribution data found in this file!"
+            return
          # Read in the coordinates of the cells:
          cell_candidate_coordinates = [self.vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
          # Read in the cell's coordinates:

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -385,7 +385,6 @@ datareducers["Dng"] =                    DataReducerVariable(["PTensor", "PParal
 
 datareducers["vBeam"] =                  DataReducerVariable(["RhoVBackstream", "RhoBackstream", "RhoVNonBackstream", "RhoNonBackstream"], v_beam, "m/s")
 datareducers["vBeamRatio"] =             DataReducerVariable(["RhoVBackstream", "RhoBackstream", "RhoVNonBackstream", "RhoNonBackstream"], v_beam_ratio, "")
-datareducers["rhoBeam"] =                DataReducerVariable(["RhoBackstream"], pass_op, "m/s")
 datareducers["vThermal"] =               DataReducerVariable(["TBackstream"], v_thermal, "m/s")
 datareducers["vThermalVector"] =         DataReducerVariable(["TTensorRotatedBackstream"], v_thermal_vector, "m/s")
 datareducers["Bz_linedipole_avg"] =      DataReducerVariable(["X", "Y", "Z", "DX", "DY", "DZ"], Bz_linedipole_avg, "T")

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -116,6 +116,31 @@ def vms( variables ):
    vms = np.sqrt( np.square(vs) + np.square(vA) )
    return vms
 
+def vs( variables ):
+   ''' Data reducer function for getting the sound speed
+   '''
+   epsilon = sys.float_info.epsilon
+   mp = 1.672622e-27
+   P = variables[0]
+   rho_m = (variables[1] + epsilon)*mp
+   vs = np.sqrt( np.divide( P*5.0/3.0, rho_m ) )
+   return vs
+
+def va( variables ):
+   ''' Data reducer function for getting the Alfven velocity
+   '''
+   epsilon = sys.float_info.epsilon
+   mp = 1.672622e-27
+   mu_0 = 1.25663706144e-6
+   rho_m = (variables[0] + epsilon)*mp
+   B = variables[1]
+   if np.ndim(B) == 1:
+      Btot = np.sqrt( np.sum( np.square(B) ) )
+   else:
+      Btot = np.sqrt( np.sum(np.square(B),axis=1) )
+   vA = np.divide( Btot,np.sqrt( mu_0*rho_m ) )
+   return vA
+
 def PTensor( variables ):
    ''' Data reducer function to reconstruct the pressure tensor from
        the vlsv diagonal and off-diagonal components.
@@ -357,6 +382,8 @@ def Dng( variables ):
 datareducers = {}
 datareducers["v"] =                      DataReducerVariable(["rho_v", "rho"], v, "m/s")
 datareducers["vms"] =                    DataReducerVariable(["Pressure", "rho", "B"], vms, "m/s")
+datareducers["vs"] =                     DataReducerVariable(["Pressure", "rho"], vs, "m/s")
+datareducers["va"] =                     DataReducerVariable(["rho", "B"], va, "m/s")
 datareducers["PTensor"] =                DataReducerVariable(["PTensorDiagonal", "PTensorOffDiagonal"], PTensor, "Pa")
 datareducers["PTensorBackstream"] =      DataReducerVariable(["PTensorBackstreamDiagonal", "PTensorBackstreamOffDiagonal"], PTensor, "Pa")
 datareducers["PTensorRotated"] =         DataReducerVariable(["PTensor", "B"], PTensorRotated, "Pa")

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -224,7 +224,7 @@ def PParallel( variables ):
       return B_normalized.dot(PTensor.dot(B_normalized))
    else:
       B_normalized = np.divide(B, np.sqrt(np.sum(B[:]**2, axis=1))[:,None])
-      return [B_normalized[i].dot(PTensor[i].dot(B_normalized[i])) for i in np.arange(len(PTensor))]
+      return np.asarray([B_normalized[i].dot(PTensor[i].dot(B_normalized[i])) for i in np.arange(len(PTensor))])
 
 def TPerpOverPar( variables ):
    TTensorRotated = variables[0]


### PR DESCRIPTION
Three bugfixes to make point-and-click velocity distribution plotting great again.

- 6c18f69 gives an error message when no vdf is stored in the file at all.
- 29174a1plots the marker of the pick location in the main window instead of the past one. Requires to store the original figure. Also gets rid of the automatic reset of the zoom of the original view.
- 719b266 removes a True threading parameter without apparent problems. This was generating nasty crashes e.g. when trying to change visualisation parameters.

Please some people test this with your favourite work flow before we merge it, hopefully in the next days.