### PR TITLE
Interactive fix

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,11 @@ import pytools as pt # Import Analysator
 pt.calculations.pitch_angles? #press [Enter]
 pt.vlsvfile.VlsvReader? #press [Enter]
 
+# For non-interactive mode (also when no X is available):
+# set the environment variable PTNONINTERACTIVE to any value before launching python/ipython
+#################################################
+#################################################
+export PTNONINTERACTIVE=1
 
 
 # For more information visit the link:

--- a/examples/generate_movie.sh
+++ b/examples/generate_movie.sh
@@ -50,5 +50,6 @@ fi;
 #echo from $start to $end 
 
 module load mayavi2
+export PTNONINTERACTIVE=1
 python generate_panel.py $start $end
 echo Job $SLURM_ARRAY_TASK_ID complete.

--- a/pytools.py
+++ b/pytools.py
@@ -25,7 +25,13 @@ except ImportError:
 
 import os
 import matplotlib.pyplot as plt
-if os.getenv('PTINTERACTIVE') != None:
+
+if os.getenv('PTNONINTERACTIVE') != None:
+   try:
+      plt.switch_backend('Agg')
+   except:
+      print "Note: Unable to switch to Agg backend"
+else:
    try:
       import grid
    except ImportError:
@@ -34,11 +40,6 @@ if os.getenv('PTINTERACTIVE') != None:
       plt.switch_backend('TkAgg')
    except:
       print "Note: Unable to switch to TkAgg backend"
-else:
-   try:
-      plt.switch_backend('Agg')
-   except:
-      print "Note: Unable to switch to Agg backend"
 
 try:
    import plot

--- a/pytools.py
+++ b/pytools.py
@@ -36,7 +36,7 @@ if os.getenv('PTINTERACTIVE') != None:
       print "Note: Unable to switch to TkAgg backend"
 else:
    try:
-   plt.switch_backend('Agg')
+      plt.switch_backend('Agg')
    except:
       print "Note: Unable to switch to Agg backend"
 

--- a/pytools.py
+++ b/pytools.py
@@ -23,15 +23,22 @@ try:
 except ImportError:
    print "Note: Did not import vlsvfile module"
 
-# For some reason, the try-catch fails on taito compute nodes.
-# This is a workaround.
-hostname=socket.gethostname()
-pattern = re.compile("c\d\d\d") # Matches hostnames of c followed by 3 digits, as in taito compute nodes
-if not pattern.match(hostname):
+import os
+import matplotlib.pyplot as plt
+if os.getenv('PTINTERACTIVE') != None:
    try:
       import grid
    except ImportError:
       print "Note: Did not import grid module"
+   try:
+      plt.switch_backend('TkAgg')
+   except:
+      print "Note: Unable to switch to TkAgg backend"
+else:
+   try:
+   plt.switch_backend('Agg')
+   except:
+      print "Note: Unable to switch to Agg backend"
 
 try:
    import plot


### PR DESCRIPTION
Here's a fix to Liisa's and my issues, discussed with @markusbattarbee.

If the environment variable PTINTERACTIVE is set (to anything), then the interactive backend is set and the grid module is loaded. Otherwise the backend is set to Agg and the grid import is skipped.