### PR TITLE
Fix in vlsvintpol

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -154,7 +154,8 @@ class VlsvReader(object):
                  pop.__dvz = ((pop.__vzmax - pop.__vzmin) / (float)(pop.__vzblocks)) / (float)(pop.__vzblock_size)
 
               self.__meshes[popname]=pop
-              print "Found population " + popname
+              if os.getenv('PTNONINTERACTIVE') == None:
+                 print "Found population " + popname
 
       self.__fptr.close()
 

--- a/tools/vlsvintpol.py
+++ b/tools/vlsvintpol.py
@@ -32,11 +32,11 @@ def extract_file(filename):
             for j,varval in enumerate(values):
                 out_line = out_line +  " " + str(varval[i])
             out.append([filename, out_line])
+        f.optimize_close_file()
     except:
         out.append([filename, "#Could not read " + filename])
         pass
     
-    f.optimize_close_file()
     return out
 
 


### PR DESCRIPTION
Took me half an hour to identify, and the cause was just a bad usage of the command line options...

If there is an invalid file (or e.g. a list file instead of a list of files passed on the command line) passed, this goes to `except:` but still tries to close `f`, which leads to `UnboundLocalError: local variable 'f' referenced before assignment`.

Better use a variant like the one below.

And it seems that the commit from last November is synonymous to later merges.