### PR TITLE
Multipop-Fixed v reducer and slippage calculation.

### DIFF
--- a/examples/generate_panel.py
+++ b/examples/generate_panel.py
@@ -180,6 +180,10 @@ for j in timetot:
     # Colour bar.and associated title.
     pt.plot.plot_colormap(filename=fileLocation+bulkname, run="BCQ",colormap='OrRd',step=j,outputdir=outputLocation+'cSHFA/', lin=1,vmin=0,vmax=1, expression=expr_cav_cust, external=cavitoncontours, pass_vars=['rho','B','beta'], pass_times=10, nocb=1, cbtitle='', boxre=[-20,20,-40,0])
 
+    # Plot a custom nightside reconnection slippage calculation
+    pt.plot.plot_helpers.slippageVA=3000000
+    pt.plot.plot_colormap(filename=fileLocation+bulkname, run="BCQ",colormap='seismic',step=j,outputdir=outputLocation+'slippage/', wmark=1, fluxdir=fluxLocation, fluxlines=4, boxre=[-40,-10,-15,15], vmin=1e-2, vmax=1e0, pass_vars=['E','B','v'])
+
    # Useful flags
    # (Find more by entering pt.plot.plot_colormap? in python
    #

--- a/pyPlots/plot_helpers.py
+++ b/pyPlots/plot_helpers.py
@@ -162,7 +162,7 @@ def VectorArrayPerpendicularVector(inputvector, directionvector):
     dirnorm = np.divide(directionvector, np.linalg.norm(directionvector, axis=-1)[:,:,np.newaxis])
     paravector = dirnorm * (inputvector*dirnorm).sum(-1)[:,:,np.newaxis] #dot product, alternatively numpy.einsum("ijk,ijk->ij",a,b)
     perpcomp = inputvector - paravector
-    # Output array is of format [nx,ny]
+    # Output array is of format [nx,ny,3]
     return perpcomp
 
 def VectorArrayAnisotropy(inputvector, directionvector):
@@ -454,7 +454,7 @@ slippageVA=3937129.92717945   #Effective alfven speed (in m/s) to use when calcu
 def expr_Slippage(pass_maps):
     # Verify that time averaging wasn't used
     if type(pass_maps[0]) is list:
-        print("exprMA_cust expected a single timestep, but got multiple. Exiting.")
+        print("expr_Slippage expected a single timestep, but got multiple. Exiting.")
         quit()
 
     expr_Slippage.__name__ = "Slippage [in v_A]"

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -114,11 +114,16 @@ def v( variables ):
    epsilon = sys.float_info.epsilon
    rho_v = variables[0]
    rho = variables[1] + epsilon
-   if np.ndim(rho) == 0:
-      return np.divide(rho_v,rho)
+   multipop_V = variables[2]
+   if np.ndim(multipop_V) == 0:
+      # Old-style single population file
+      if np.ndim(rho) == 0:
+         return np.divide(rho_v,rho)
+      else:
+         rho = np.reshape(rho,(len(rho),1))
+         return np.divide(rho_v,rho)
    else:
-      rho = np.reshape(rho,(len(rho),1))
-      return np.divide(rho_v,rho)
+       return multipop_V
 
 def vms( variables ):
    ''' Data reducer function for getting magnetosonic velocity
@@ -417,7 +422,7 @@ def Dng( variables ):
 
 #datareducers with more complex, case dependent structure.
 datareducers = {}
-datareducers["v"] =                      DataReducerVariable(["rho_v", "rho"], v, "m/s")
+datareducers["v"] =                      DataReducerVariable(["rho_v", "rho", "V"], v, "m/s")
 datareducers["vms"] =                    DataReducerVariable(["Pressure", "rho", "B"], vms, "m/s")
 datareducers["vs"] =                     DataReducerVariable(["Pressure", "rho"], vs, "m/s")
 datareducers["va"] =                     DataReducerVariable(["rho", "B"], va, "m/s")


### PR DESCRIPTION
This pull request does two things:
* Fixes the 'v' datareducer in analysator to work with both multipop and old files.
* Adds a slippage [ (E×B-V)/vA ] calculation to the plot_helpers file. Includes an example line, too!