### PR TITLE
added cut_through_step for optimized non-jumpy cut-throughs

### DIFF
--- a/pyCalculations/calculations.py
+++ b/pyCalculations/calculations.py
@@ -39,7 +39,7 @@ pt.calculations.fourier?
 # List of functions and classes that should be imported into the interface
 from intpol_file import vlsv_intpol_file
 from intpol_points import vlsv_intpol_points
-from cutthrough import cut_through
+from cutthrough import cut_through, cut_through_step
 from fourier import fourier
 from variable import VariableInfo
 from timeevolution import cell_time_evolution

--- a/pyCalculations/cutthrough.py
+++ b/pyCalculations/cutthrough.py
@@ -153,4 +153,76 @@ def cut_through( vlsvReader, point1, point2 ):
 
 
 
+def cut_through_step( vlsvReader, point1, point2 ):
+   ''' Returns cell ids and distances from point 1 to point 2, returning not every cell in a line
+       but rather the amount of cells which correspons with the largest axis-aligned component of the line.
 
+       :param vlsvReader:       Some open VlsvReader
+       :type vlsvReader:        :class:`vlsvfile.VlsvReader`
+       :param point1:           The starting point of a cut-through line
+       :param point2:           The ending point of a cut-through line
+       :returns: an array containing cell ids, coordinates and distances in the following format: [cell ids, distances, coordinates]
+
+       .. code-block:: python
+
+          Example:
+          vlsvReader = VlsvReader(\"testfile.vlsv\")
+          cut_through = cut_through_step(vlsvReader, [0,0,0], [2,5e6,0])
+          cellids = cut_through[0]
+          distances = cut_through[1]
+          print \"Cell ids: \" + str(cellids)
+          print \"Distance from point 1 for every cell: \" + str(distances)
+   '''
+   # Transform point1 and point2 into numpy array:
+   point1 = np.array(point1)
+   point2 = np.array(point2)
+
+   # Make sure point1 and point2 are inside bounds
+   if vlsvReader.get_cellid(point1) == 0:
+      print "ERROR, POINT1 IN CUT-THROUGH OUT OF BOUNDS!"
+   if vlsvReader.get_cellid(point2) == 0:
+      print "ERROR, POINT2 IN CUT-THROUGH OUT OF BOUNDS!"
+   
+   # Find path
+   distances = point2-point1
+   largestindex = np.argmax(abs(distances))
+   derivative = distances/abs(distances[largestindex])
+
+   # Re=6371000.
+   # print("distances",distances/Re)
+   # print("largestindex",largestindex)
+   # print("derivative",derivative)
+
+   # Get parameters from the file to determine a good length between points (step length):
+   # Get xmax, xmin and xcells_ini   
+   [xcells, ycells, zcells] = vlsvReader.get_spatial_mesh_size()
+   [xmin, ymin, zmin, xmax, ymax, zmax] = vlsvReader.get_spatial_mesh_extent()
+
+   # Calculate cell lengths:
+   cell_lengths = np.array([(xmax - xmin)/(float)(xcells), (ymax - ymin)/(float)(ycells), (zmax - zmin)/(float)(zcells)])
+
+
+   # Initialize lists
+   distances = [0]
+   cellids = [vlsvReader.get_cellid(point1)]
+   coordinates = [point1]
+   finalcellid = vlsvReader.get_cellid(point2)
+   print(" cellids init ",cellids,finalcellid)
+
+   # Loop until final cellid is reached
+   while True:
+      newcoordinate = coordinates[-1]+cell_lengths*derivative
+      newcellid = vlsvReader.get_cellid( newcoordinate )
+
+      distances.append( np.linalg.norm( newcoordinate - point1 ) )
+      coordinates.append(newcoordinate)
+      cellids.append(newcellid)
+      #print(distances[-1]/Re,np.array(coordinates[-1])/Re,cellids[-1])
+
+      if newcellid==finalcellid:
+         break
+      
+   # Return the coordinates, cellids and distances for processing
+   from output import output_1d
+   return output_1d( [np.array(cellids, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["CellID", "distances", "coordinates"], ["", "m", "m"] )
+      


### PR DESCRIPTION
This acts like cut_through, except instead of returning every cell through which the line passes, it finds the dominant cartesian direction, and proceeds to always return the next cell in that dominant direction through which the actual line passes. This should prevent jagged artefacts when plotting diagonal lineouts without having to resort to the dampening done by lineout.