### PR TITLE
Wrap read_interpolated_variable's data size determination in a try block

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -760,7 +760,11 @@ class VlsvReader(object):
 
          test_val=self.read_variable(name,lower_cell_id,operator)
          if isinstance(test_val, Iterable):
-            value_length=len(test_val)
+            try:
+               value_length=len(test_val)
+            except Exception as e:
+               # Can't determine size, maybe some division by zero?
+               value_length=1
          else:
             value_length=1
          


### PR DESCRIPTION
This catches the special case in which a derived variable evaluates to
NaN (such as TPerpOverPar), gets masked away, creates an array with zero
effective size, and then all hell breaks loose.