### PR TITLE
Pass cellids to reducers and improve performance of multi-cellid reads

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -561,17 +561,19 @@ class VlsvReader(object):
       :param tag:  Tag of the data array.
       :param mesh: Mesh for the data array
       :param operator: Datareduction operator. "pass" does no operation on data.
-      :param cellids:  If -1 then all data is read. If nonzero then only the vector for the specified cell id or cellids is read
+      :param cellids:  If -1 then all data is read. If nonzero then only the vector
+                       for the specified cell id or cellids is read
       :returns: numpy array with the data
 
       .. seealso:: :func:`read_variable` :func:`read_variable_info`
       '''
 
       if (len( self.__fileindex_for_cellid ) == 0):
-         if type(cellids) == int:
-            if cellids >= 0:
+         # Do we need to construct the cellid index?
+         if type(cellids) == int: # single or all cells
+            if cellids >= 0: # single cell
                self.__read_fileindex_for_cellid()
-         else:
+         else: # list of cellids
             self.__read_fileindex_for_cellid()
                
       if tag == "" and name == "" and tag == "":
@@ -606,78 +608,79 @@ class VlsvReader(object):
             if "mesh" in child.attrib and child.attrib["mesh"] != mesh:
                continue
          if child.tag == tag:
+            # Found the requested data in the file
+            variable_offset = ast.literal_eval(child.text)
             vector_size = ast.literal_eval(child.attrib["vectorsize"])
             array_size = ast.literal_eval(child.attrib["arraysize"])
             element_size = ast.literal_eval(child.attrib["datasize"])
             datatype = child.attrib["datatype"]
-            offset = ast.literal_eval(child.text)
-            # if read_single_cellid >= 0:
-            #    offset=offset+self.__fileindex_for_cellid[read_single_cellid]*element_size*vector_size
-            #    array_size=1
+
+            # Define efficient method to read data in
             if type(cellids) == int: # single cell or all cells
-               if cellids >= 0:
-                  offset=offset+self.__fileindex_for_cellid[cellids]*element_size*vector_size
-                  array_size=1
-               # Read single cell or all cells
-               fptr.seek(offset)
+               if cellids < 0: # -1, read all cells
+                  result_size = array_size
+                  read_size = array_size
+                  read_offsets = [0]
+               else: # single cell id
+                  result_size = 1
+                  read_size = 1
+                  read_offsets = [self.__fileindex_for_cellid[cellids]*element_size*vector_size]
+            else: # Read multiple specified cells
+               arraydata = []
+               # If we're reading a large amount of single cells, it'll be faster to just read all
+               # data from the file system and sort through it. For the CSC disk system, this
+               # becomes more efficient for over ca. 5000 cellids.
+               if len(cellids)>5000: 
+                  result_size = len(cellids)
+                  read_size = array_size
+                  read_offsets = [0]
+               else: # Read multiple cell ids one-by-one
+                  result_size = len(cellids)
+                  read_size = 1
+                  read_offsets = [self.__fileindex_for_cellid[cid]*element_size*vector_size for cid in cellids]
+                  
+            for r_offset in read_offsets:
+               use_offset = variable_offset + r_offset
+               fptr.seek(use_offset)
                if datatype == "float" and element_size == 4:
-                  data = np.fromfile(fptr, dtype = np.float32, count=vector_size*array_size)
+                  data = np.fromfile(fptr, dtype = np.float32, count=vector_size*read_size)
                if datatype == "float" and element_size == 8:
-                  data = np.fromfile(fptr, dtype=np.float64, count=vector_size*array_size)
+                  data = np.fromfile(fptr, dtype=np.float64, count=vector_size*read_size)
                if datatype == "int" and element_size == 4:
-                  data = np.fromfile(fptr, dtype=np.int32, count=vector_size*array_size)
+                  data = np.fromfile(fptr, dtype=np.int32, count=vector_size*read_size)
                if datatype == "int" and element_size == 8:
-                  data = np.fromfile(fptr, dtype=np.int64, count=vector_size*array_size)
+                  data = np.fromfile(fptr, dtype=np.int64, count=vector_size*read_size)
                if datatype == "uint" and element_size == 4:
-                  data = np.fromfile(fptr, dtype=np.uint32, count=vector_size*array_size)
+                  data = np.fromfile(fptr, dtype=np.uint32, count=vector_size*read_size)
                if datatype == "uint" and element_size == 8:
-                  data = np.fromfile(fptr, dtype=np.uint64, count=vector_size*array_size)
-            else:
-               # Read multiple cells
-               if len(cellids)>20:
-                  # Reads all the values for variable and sorts the array according to Cell ID order
-                  all_cells = self.read_variable(name="CellID",cellids=-1,operator="pass")
-                  variable = self.read(mesh="SpatialGrid", name=name, tag="VARIABLE", operator=operator, cellids=-1)
-                  variable = variable[all_cells.argsort()]
-                  # Pick the elements corresponding to the cells you want
-                  data=np.array(variable[np.array(cellids)-1])
-                  array_size = len(cellids)
-                  #print(cellids)
-               else:
-                  arraydata = []               
-                  array_size = len(cellids)
-                  for i,cid in enumerate(cellids):
-                     offset = ast.literal_eval(child.text)
-                     offset=offset+self.__fileindex_for_cellid[cid]*element_size*vector_size
-                     fptr.seek(offset)
-                     if datatype == "float" and element_size == 4:
-                        data = np.fromfile(fptr, dtype = np.float32, count=vector_size)
-                     if datatype == "float" and element_size == 8:
-                        data = np.fromfile(fptr, dtype=np.float64, count=vector_size)
-                     if datatype == "int" and element_size == 4:
-                        data = np.fromfile(fptr, dtype=np.int32, count=vector_size)
-                     if datatype == "int" and element_size == 8:
-                        data = np.fromfile(fptr, dtype=np.int64, count=vector_size)
-                     if datatype == "uint" and element_size == 4:
-                        data = np.fromfile(fptr, dtype=np.uint32, count=vector_size)
-                     if datatype == "uint" and element_size == 8:
-                        data = np.fromfile(fptr, dtype=np.uint64, count=vector_size)
-                     arraydata.append(data)
-                  data = np.array(arraydata)
+                  data = np.fromfile(fptr, dtype=np.uint64, count=vector_size*read_size)
+               if len(read_offsets)!=1:
+                  arraydata.append(data)
+            
+            if len(read_offsets)==1 and result_size<read_size:
+               # Many single cell id's requested
+               # Pick the elements corresponding to the requested cells
+               for cid in cellids:
+                  append_offset = self.__fileindex_for_cellid[cid]*vector_size
+                  arraydata.append(data[append_offset:append_offset+vector_size])
+               data = np.array(arraydata)
+
+            if len(read_offsets)!=1:
+               # Not-so-many single cell id's requested
+               data = np.array(arraydata)
 
             if self.__fptr.closed:
                fptr.close()
 
             if vector_size > 1:
-               #print(array_size, vector_size, name)
-               data=data.reshape(array_size, vector_size)
+               data=data.reshape(result_size, vector_size)
             
             # If variable vector size is 1, and requested magnitude, change it to "absolute"
             if vector_size == 1 and operator=="magnitude":
                print("Data variable with vector size 1: Changed magnitude operation to absolute")
                operator="absolute"
 
-            if array_size == 1:
+            if result_size == 1:
                return data_operators[operator](data[0])
             else:
                return data_operators[operator](data)
@@ -906,21 +909,8 @@ class VlsvReader(object):
       .. seealso:: :func:`read` :func:`read_variable_info`
       '''
       cellids = get_data(cellids)
+      # Passes the list of cell id's onwards - optimization for reading is done in the lower level read() method
       return self.read(mesh="SpatialGrid", name=name, tag="VARIABLE", operator=operator, cellids=cellids)
-      # if len(np.shape(cellids)) == 0:
-      #    return self.read(mesh="SpatialGrid", name=name, tag="VARIABLE", operator=operator, cellids=cellids)
-      # else:
-      #    if len(cellids)>20:
-      #       # Reads all the values for variable and sorts the array according to Cell ID order
-      #       all_cells = self.read_variable(name="CellID",cellids=-1,operator="pass")
-      #       variable = self.read(mesh="SpatialGrid", name=name, tag="VARIABLE", operator=operator, cellids=-1)
-      #       variable = variable[all_cells.argsort()]
-         
-      #       # Pick the elements corresponding to the cells you want
-      #       return variable[np.array(cellids)-1]
-      #    else:
-      #       # Read the variables for just the cells we need
-      #       return self.read(mesh="SpatialGrid", name=name, tag="VARIABLE", operator=operator, cellids=cellids)
 
    def read_variable_info(self, name, cellids=-1, operator="pass"):
       ''' Read variables from the open vlsv file and input the data into VariableInfo

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -608,12 +608,12 @@ class VlsvReader(object):
             if "mesh" in child.attrib and child.attrib["mesh"] != mesh:
                continue
          if child.tag == tag:
-            # Found the requested data in the file
-            variable_offset = ast.literal_eval(child.text)
+            # Found the requested data entry in the file
             vector_size = ast.literal_eval(child.attrib["vectorsize"])
             array_size = ast.literal_eval(child.attrib["arraysize"])
             element_size = ast.literal_eval(child.attrib["datasize"])
             datatype = child.attrib["datatype"]
+            variable_offset = ast.literal_eval(child.text)
 
             # Define efficient method to read data in
             if type(cellids) == int: # single cell or all cells
@@ -663,11 +663,11 @@ class VlsvReader(object):
                for cid in cellids:
                   append_offset = self.__fileindex_for_cellid[cid]*vector_size
                   arraydata.append(data[append_offset:append_offset+vector_size])
-               data = np.array(arraydata)
+               data = np.squeeze(np.array(arraydata))
 
             if len(read_offsets)!=1:
                # Not-so-many single cell id's requested
-               data = np.array(arraydata)
+               data = np.squeeze(np.array(arraydata))
 
             if self.__fptr.closed:
                fptr.close()


### PR DESCRIPTION
This is an enhancement in response to #84 

Instead of doing read loops over data reducers and performing a large number of separate file accesses, the list of cellids is passed on to the lowest-level function. Data reduction calculations (e.g. rotations for parallel and perpendicular values) are only performed for the requested data.

If requesting more than 5000 cellids in one call, the reader reads the whole data instead in one file access and then sifts through it using the built-in vlsvreader cellid dictionary.