### PR TITLE
Fixed bug with linear colorbar ticks

### DIFF
--- a/pyPlots/plot_colormap.py
+++ b/pyPlots/plot_colormap.py
@@ -375,7 +375,7 @@ def plot_colormap(filename=None,
         if operator=='x' or operator=='y' or operator=='z':
             # For components, always use linear scale, unless symlog is set
             operatorstr='_'+operator
-            if symlog==None:
+            if symlog==None and lin is None:
                 lin=True
         # index a vector
         if operator.isdigit():


### PR DESCRIPTION
I found a bug with the "lin" keyword in plot_colormap. It was automatically set to True when the symlog option was not used, and as a result setting the number of colorbar ticks with this keyword didn't work anymore.