### PR TITLE
Fixed bug when op(erator)=0 which resulted in 'pass' instead of …

### DIFF
--- a/pyPlots/plot_colormap.py
+++ b/pyPlots/plot_colormap.py
@@ -278,14 +278,14 @@ def plot_colormap(filename=None,
             print("Error locating flux function file!")
             fluxfile=None
                 
-    if not operator:
-        if op:
+    if operator is None:
+        if op is not None:
             operator=op
 
     if not colormap:
         # Default values
         colormap="hot_desaturated"
-        if operator and operator in 'xyz':
+        if operator is not None and operator in 'xyz':
             colormap="bwr"
     cmapuse=matplotlib.cm.get_cmap(name=colormap)
 
@@ -329,7 +329,7 @@ def plot_colormap(filename=None,
     # Verify validity of operator
     operatorstr=''
     operatorfilestr=''
-    if operator:
+    if operator is not None:
         # .isdigit checks if the operator is an integer (for taking an element from a vector)
         if type(operator) is int:
             operator = str(operator)
@@ -471,7 +471,7 @@ def plot_colormap(filename=None,
     ##########
     if not expression:        
         # Read data from file
-        if not operator:
+        if operator is None:
             operator="pass"
         datamap_info = f.read_variable_info(var, operator=operator)
 

--- a/pyPlots/plot_colormap3dslice.py
+++ b/pyPlots/plot_colormap3dslice.py
@@ -254,14 +254,14 @@ def plot_colormap3dslice(filename=None,
         print("Error, needs a .vlsv file name, python object, or directory and step")
         return
     
-    if not operator:
-        if op:
+    if operator is None:
+        if op is not None:
             operator=op
 
     if not colormap:
         # Default values
         colormap="hot_desaturated"
-        if operator and operator in 'xyz':
+        if operator is not None and operator in 'xyz':
             colormap="bwr"
     cmapuse=matplotlib.cm.get_cmap(name=colormap)
 
@@ -308,7 +308,7 @@ def plot_colormap3dslice(filename=None,
     # Verify validity of operator
     operatorstr=''
     operatorfilestr=''
-    if operator:
+    if operator is not None:
         # .isdigit checks if the operator is an integer (for taking an element from a vector)
         if type(operator) is int:
             operator = str(operator)
@@ -538,7 +538,7 @@ def plot_colormap3dslice(filename=None,
     ############################################
     if not expression:        
         # Read data from file
-        if not operator:
+        if operator is None:
             operator="pass"
         datamap_info = f.read_variable_info(var, operator=operator)
 

--- a/pyPlots/plot_threeslice.py
+++ b/pyPlots/plot_threeslice.py
@@ -718,14 +718,14 @@ def plot_threeslice(filename=None,
         print("Error, needs a .vlsv file name, python object, or directory and step")
         return
 
-    if not operator:
-        if op:
+    if operator is None:
+        if op is not None:
             operator=op
 
     if not colormap:
         # Default values
         colormap="hot_desaturated"
-        if operator and operator in 'xyz':
+        if operator is not None and operator in 'xyz':
             colormap="bwr"
     cmapuse=matplotlib.cm.get_cmap(name=colormap)
 
@@ -772,7 +772,7 @@ def plot_threeslice(filename=None,
     # Verify validity of operator
     operatorstr=''
     operatorfilestr=''
-    if operator:
+    if operator is not None:
         # .isdigit checks if the operator is an integer (for taking an element from a vector)
         if type(operator) is int:
             operator = str(operator)
@@ -1034,7 +1034,7 @@ def plot_threeslice(filename=None,
     ############################################
     if not expression:
         # Read data from file
-        if not operator:
+        if operator is None:
             operator="pass"
         datamap_info = f.read_variable_info(var, operator=operator)
 


### PR DESCRIPTION
…taking the zeroth component

This has been tested:
– on BCH bulk files: plot_colormap of B with op in [None,0,'x'];
– on EGI bulk files: plot_colormap3dslice and plot_threeslice 
      * of vg_b_vol with op or operator in [None,0,'x',1,'y'], 
      * and of proton/vg_precipitationdifferentialflux with op in [0,1,5].