### PR TITLE
corrected task indexing in vlsvreader for fsgrids

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1003,13 +1003,13 @@ class VlsvReader(object):
            processDomainDecomposition = [1,1,1]
            processBox = [0,0,0]
            optimValue = 999999999999999.
-           for i in range(1,min(ntasks,globalsize[0]+1)):
+           for i in range(1,min(ntasks,globalsize[0])+1):
                processBox[0] = max(1.*globalsize[0]/i,1)
-               for j in range(1,min(ntasks,globalsize[1]+1)):
+               for j in range(1,min(ntasks,globalsize[1])+1):
                    if(i * j > ntasks):
                        break
                    processBox[1] = max(1.*globalsize[1]/j,1)
-                   for k in range(1,min(ntasks,globalsize[2]+1)):
+                   for k in range(1,min(ntasks,globalsize[2])+1):
                        if(i * j * k > ntasks):
                            continue
                        processBox[2] = max(1.*globalsize[2]/k,1)
@@ -1021,6 +1021,9 @@ class VlsvReader(object):
                            if value < optimValue:
                               optimValue = value
                               processDomainDecomposition=[i,j,k]
+           if (np.prod(processDomainDecomposition) != ntasks):
+              print("Mismatch in FSgrid rank decomposition")
+              return -1
            return processDomainDecomposition
 
        def calcLocalStart(globalCells, ntasks, my_n):


### PR DESCRIPTION
Issue with indexing was cropping up especially in small spatial domains and small task counts. Fixed.
<img width="1127" alt="Screenshot 2021-09-24 at 08 56 30" src="https://user-images.githubusercontent.com/11755746/134625429-f29b0373-36ea-476a-88f1-fd46fd3ca89f.png">
<img width="1160" alt="Screenshot 2021-09-24 at 08 55 53" src="https://user-images.githubusercontent.com/11755746/134625444-fc541e7b-f203-481d-b840-cd706d694ac1.png">

