### PR TITLE
Fs Grid data interpolation

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -864,7 +864,7 @@ class VlsvReader(object):
          at arbitrary coordinates r.
          Inputs:
              r: array of coordinates at which to perform the interpolation. 
-                Example: r=[x,y,z]
+                Example: r=[x,y,z] in meters
          Outputs:
              Numpy array with interpolated data at r. Can be scalar or vector.
          '''

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -839,8 +839,10 @@ class VlsvReader(object):
 
       print(extents)
 
-      def getFsGridIndex(indices):
-         
+      def getFsGridIndices(indices):
+         ''' 
+         Returns indices based on boundary conditions
+         '''
          ind=-1*np.ones((3))
          for c,index in enumerate(indices):
             #Non periodic case
@@ -862,11 +864,15 @@ class VlsvReader(object):
 
 
       def interpolateSingle(r):
-         import  sys
-
-         #First off let's handle boundaries
-         x,y,z=r
-
+         ''' 
+         Simple trilinear routine for interpolating fsGrid quantities 
+         at arbitrary coordinates r.
+         Inputs:
+             r: array of coordinates at which to perform the interpolation. 
+                Example: r=[x,y,z]
+         Outputs:
+             interpolated data at r. Can be scalar or variable.
+         '''
 
          #Find last spatial neighbor
          '''
@@ -880,6 +886,7 @@ class VlsvReader(object):
          |   *       |/
          X-----------+
          '''
+         x,y,z=r
          xl=int(np.floor((x-xmin)/dx))
          yl=int(np.floor((y-ymin)/dy))
          zl=int(np.floor((z-zmin)/dz))
@@ -891,7 +898,7 @@ class VlsvReader(object):
          zd=(z-(zl*dz-abs(zmin)))/dz
 
          # Calculate Neighbors' Weights
-         w=np.zeros((8))
+         w=np.zeros(8)
          w[0] = (1.0-xd)*(1.0-yd)*(1.0-zd)
          w[1] = (1.0-xd)*(yd)*(1.0-zd)
          w[2] = (xd)*(1.0-yd)*(1.0-zd)
@@ -909,7 +916,7 @@ class VlsvReader(object):
          for a in [0,1]:
             for b in [0,1]:
                for c  in [0,1]:
-                  ind=getFsGridIndex([xl+b,yl+c,zl+a])
+                  ind=getFsGridIndices([xl+b,yl+c,zl+a])
                   if (not ind): return np.nan
                   retval += w[cnt] * fg_data[ind]
                   cnt+=1
@@ -919,7 +926,6 @@ class VlsvReader(object):
       ret=[]
       for r in coordinates:
          ret.append(interpolateSingle(r))
-
       return ret
 
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1479,7 +1479,7 @@ class VlsvReader(object):
                   ngbr_indices[i] = ngbr_indices[i] - sys_size[i]
    
          elif ngbr_indices[i] < 0 or  ngbr_indices[i] >= sys_size[i]:
-            # print("Error in Vlsvreader get_cell_neighbor: out of bounds")
+            print("Error in Vlsvreader get_cell_neighbor: out of bounds")
             return 0
 
       coord_neighbour = np.array([self.__xmin,self.__ymin,self.__zmin]) + (ngbr_indices + np.array((0.5,0.5,0.5))) * np.array([self.__dx,self.__dy,self.__dz])/2**reflevel

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -837,7 +837,6 @@ class VlsvReader(object):
       periodicity[1]=True if periodic[1] =="True" else False
       periodicity[2]=True if periodic[2] =="True" else False
 
-      print(extents)
 
       def getFsGridIndices(indices):
          ''' 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -821,6 +821,8 @@ class VlsvReader(object):
       #First off let's fetch the data and some meta
       fg_data=self.read_fsgrid_variable( name,operator=operator)
       fg_size=self.get_fsgrid_mesh_size()
+      print(fg_size)
+      print(np.shape(fg_data))
       fg_data=np.reshape(fg_data,fg_size)
       nx,ny,nz=fg_size
       extents=self.get_fsgrid_mesh_extent()
@@ -844,7 +846,6 @@ class VlsvReader(object):
             if ((index<0 or index>fg_size[c]-1) and not periodicity[c]):
                #out of bounds return NaN
                return False
-
              # Here we are either periodic or (not periodic and inside the domain)
             if (index >= fg_size[c] or index <0):
                 ind[c] = index%fg_size[c]
@@ -883,7 +884,7 @@ class VlsvReader(object):
          '''
          import sys
          if (len(r) !=3 ):
-            print("Interpolation input data should be in the form X,Y,Z coordinates. Input now is r=",r,file=sys.stderr)
+            # print("Interpolation input data should be in the form X,Y,Z coordinates. Input now is r=",r,file=sys.stderr)
             raise ValueError("Interpolation cannot be performed. Exiting")
 
 
@@ -911,15 +912,13 @@ class VlsvReader(object):
          w[7] = (xd)*(yd)*(zd)
 
          retval = np.zeros_like(fg_data[0,0,0])
-         cnt=0
          for k in [0,1]:
             for j in [0,1]:
                for i in [0,1]:
                   retind=getFsGridIndices([xl+i,yl+j,zl+k])
                   if (not retind): return None
                   if  (retind == -1 ): return np.NaN
-                  retval += w[cnt] * fg_data [retind]
-                  cnt+=1
+                  retval += w[4*k+2*j+i]*fg_data[retind]
 
          return retval
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -803,7 +803,7 @@ class VlsvReader(object):
       return -1
          
 
-   def read_interpolated_fsgrid_variable(self, name, coordinates, operator="pass",periodic=["True", "True", "True"]):
+   def read_interpolated_fsgrid_variable(self, name, coordinates, operator="pass",periodic=[True,True,True]):
       ''' Read a linearly interpolated FSgrid variable value from the open vlsv file.
       Arguments:
       :param name: Name of the (FSgrid) variable
@@ -828,11 +828,6 @@ class VlsvReader(object):
       dx=abs((xmax-xmin)/nx)
       dy=abs((ymax-ymin)/ny)
       dz=abs((zmax-zmin)/nz)
-      periodicity=np.ones(3,dtype=bool)
-      periodicity[0]=True if periodic[0] =="True" else False
-      periodicity[1]=True if periodic[1] =="True" else False
-      periodicity[2]=True if periodic[2] =="True" else False
-
 
       def getFsGridIndices(indices):
          ''' 
@@ -841,7 +836,7 @@ class VlsvReader(object):
          ind=-1*np.ones((3))
          for c,index in enumerate(indices):
             #Non periodic case
-            if ((index<0 or index>fg_size[c]-1) and not periodicity[c]):
+            if ((index<0 or index>fg_size[c]-1) and not periodic[c]):
                #out of bounds return NaN
                return False
              # Here we are either periodic or (not periodic and inside the domain)
@@ -869,7 +864,6 @@ class VlsvReader(object):
          '''
          import sys
          if (len(r) !=3 ):
-            # print("Interpolation input data should be in the form X,Y,Z coordinates. Input now is r=",r,file=sys.stderr)
             raise ValueError("Interpolation cannot be performed. Exiting")
 
          x,y,z=r
@@ -914,7 +908,7 @@ class VlsvReader(object):
 
 
 
-   def read_interpolated_variable(self, name, coordinates, operator="pass",periodic=["True", "True", "True"]):
+   def read_interpolated_variable(self, name, coordinates, operator="pass",periodic=[True,True,True]):
       ''' Read a linearly interpolated variable value from the open vlsv file.
       Arguments:
       :param name: Name of the variable
@@ -925,6 +919,9 @@ class VlsvReader(object):
 
       .. seealso:: :func:`read` :func:`read_variable_info`
       '''
+
+      if (len(periodic)!=3):
+            raise ValueError("Periodic must be a list of 3 booleans.")
 
       # First test whether the requested variable is on the FSgrid, and redirect to the dedicated function if needed
       if name[0:3] == 'fg_':

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -817,6 +817,9 @@ class VlsvReader(object):
  
       if name[0:3] != 'fg_':
          raise ValueError("Interpolation of FsGrid called on non-FsGrid data; exiting.")
+      
+      if (len(periodic)!=3):
+         raise ValueError("Periodic must be a list of 3 booleans.")
 
       #First off let's fetch the data and some meta
       fg_data=self.read_fsgrid_variable( name,operator=operator)


### PR DESCRIPTION
This implements a trilinear interpolation routine for FsGrid data and tries to resolve issue #136 .
Boundaries are handled  the following way:

- If a point is outside of a non periodic domain NaN is returned. My thought proccess here is that maybe we have some SC orbit and that goes out of our domain during some part of it. Then we would not want to discard all the orbit but only part of it. Hence the NaN returned there.
- If a point is outside of a  periodic domain  then the neighbor is only given if the point is one cell away of the periodic dimension. Otherwise a NaN is returned. (here we could fold over the point back into the domain like particles in PIC but not sure what you think)
- If a point is inside the domain but one of its neighbors cannot be located then a NaN is returned. Here we could revert to a nearest neighbor approach.

Have tested this with 2D runs, AMR on/off 3D runs, periodic dimensions , scalar and vector variables.

Example of interpolation in an AMR test run :
![interpolated](https://user-images.githubusercontent.com/38067188/153753904-c89882c6-14d8-467e-957a-6a765f39e141.png)
