### PR TITLE
Extendedmanual matplotlib colormaps inclusion to work the same way as…

### DIFF
--- a/pyPlots/colormaps.py
+++ b/pyPlots/colormaps.py
@@ -1110,20 +1110,28 @@ _parula_data = [[0.2081, 0.1663, 0.5292],
 from matplotlib.colors import LinearSegmentedColormap
 cmaps = {}
 for (name, data) in (('magma', _magma_data),
+                     ('magma_r', _magma_data[::-1]),
                      ('inferno', _inferno_data),
+                     ('inferno_r', _inferno_data[::-1]),
                      ('plasma', _plasma_data),
+                     ('plasma_r', _plasma_data[::-1]),
                      ('viridis', _viridis_data),
+                     ('viridis_r', _viridis_data[::-1]),
                      ('parula', _parula_data),
                      ('parula_r', _parula_data[::-1])):
 
     cmaps[name] = LinearSegmentedColormap.from_list(name, data)
 # Some of these are already included in newer versions of matplotlib
-magma = cmaps['magma']
-inferno = cmaps['inferno']
-plasma = cmaps['plasma']
-viridis = cmaps['viridis']
-parula = cmaps['parula']
-parula_r = cmaps['parula_r']
+magma     = cmaps['magma']
+magma_r   = cmaps['magma_r']
+inferno   = cmaps['inferno']
+inferno_r = cmaps['inferno_r']
+plasma    = cmaps['plasma']
+plasma_r  = cmaps['plasma_r']
+viridis   = cmaps['viridis']
+viridis_r = cmaps['viridis_r']
+parula    = cmaps['parula']
+parula_r  = cmaps['parula_r']
 
 # Themis colormap, as extracted from the themis tools' IDL file
 hot_desaturated_colors=[(71./255.,71./255.,219./255.),(0,0,91./255.),(0,1,1),(0,.5,0),(1,1,0),(1,96./255,0),(107./255,0,0),(224./255,76./255,76./255)]

--- a/pyPlots/plot.py
+++ b/pyPlots/plot.py
@@ -52,13 +52,13 @@ import numpy as np, os
 
 if LooseVersion(matplotlib.__version__) < LooseVersion("3.3.0"):
     plt.register_cmap(name='viridis', cmap=cmaps.viridis)
-    plt.register_cmap(name='viridis_r', cmap=matplotlib.colors.ListedColormap(cmaps.viridis.colors[::-1]))
+    plt.register_cmap(name='viridis_r', cmap=cmaps.viridis_r)
     plt.register_cmap(name='plasma', cmap=cmaps.plasma)
-    plt.register_cmap(name='plasma_r', cmap=matplotlib.colors.ListedColormap(cmaps.plasma.colors[::-1]))
+    plt.register_cmap(name='plasma_r', cmap=cmaps.plasma_r)
     plt.register_cmap(name='inferno', cmap=cmaps.inferno)
-    plt.register_cmap(name='inferno_r', cmap=matplotlib.colors.ListedColormap(cmaps.inferno.colors[::-1]))
+    plt.register_cmap(name='inferno_r', cmap=cmaps.inferno_r)
     plt.register_cmap(name='magma', cmap=cmaps.magma)
-    plt.register_cmap(name='magma_r', cmap=matplotlib.colors.ListedColormap(cmaps.magma.colors[::-1]))
+    plt.register_cmap(name='magma_r', cmap=cmaps.magma_r)
 
 # Register custom colourmaps
 plt.register_cmap(name='parula', cmap=cmaps.parula)


### PR DESCRIPTION
… parula construction in #168. Since the LinearSegmentedColormaps still don't have the member `colors`, which still trigger with matplotlibs < 3.3.0 (e.g. on available Turso modules..)