### PR TITLE
cut_through and cut_through_step for FSGrid

### DIFF
--- a/pyCalculations/calculations.py
+++ b/pyCalculations/calculations.py
@@ -39,7 +39,7 @@ pt.calculations.fourier?
 # List of functions and classes that should be imported into the interface
 from intpol_file import vlsv_intpol_file
 from intpol_points import vlsv_intpol_points
-from cutthrough import cut_through, cut_through_step, cut_through_curve, cut_through_swath
+from cutthrough import cut_through, cut_through_step, cut_through_curve, cut_through_swath, fsgrid_cut_through, fsgrid_cut_through_step
 from fourier import fourier
 from spectra import get_spectrum_energy, get_spectrum_alongaxis_vel
 from variable import VariableInfo

--- a/pyCalculations/cutthrough.py
+++ b/pyCalculations/cutthrough.py
@@ -370,7 +370,6 @@ def get_fsgrid_indices_coordinates_distances( vlsvReader, xmax, xmin, xcells, ym
        :param point2:           The ending point of a cut-through line
        :returns: Coordinates of for the cell cut-through as well as cell indices and distances
    '''
-   from output import output_1d
 
    point1 = np.array(point1, copy=False)
    point2 = np.array(point2, copy=False)
@@ -380,10 +379,6 @@ def get_fsgrid_indices_coordinates_distances( vlsvReader, xmax, xmin, xcells, ym
    indices = [vlsvReader.get_fsgrid_cell_index(point1)]
 
    coordinates = [point1]
-
-   if np.array_equal(point1,point2):
-      
-      return output_1d( [np.array(indices, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["fsgrid_cell_index", "distances", "coordinates"], ["", "m", "m"] )
 
    epsilon = sys.float_info.epsilon*2
 
@@ -436,6 +431,7 @@ def get_fsgrid_indices_coordinates_distances( vlsvReader, xmax, xmin, xcells, ym
       if min((point2 - iterator)* unit_vector) < 0:
          break
    # Return the coordinates, cellids and distances for processing
+   from output import output_1d
    return output_1d( [np.array(indices, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["fsgrid_cell_index", "distances", "coordinates"], ["", "m", "m"] )
 
 

--- a/pyCalculations/cutthrough.py
+++ b/pyCalculations/cutthrough.py
@@ -67,12 +67,13 @@ def get_cellids_coordinates_distances( vlsvReader, xmax, xmin, xcells, ymax, ymi
       # Check which boundary we hit first when we move in the unit_vector direction:
       coefficients_min = np.divide((min_bounds - iterator), unit_vector, out=np.full(min_bounds.shape, sys.float_info.max), where=np.logical_not(unit_vector==0.0))
       coefficients_max = np.divide((max_bounds - iterator), unit_vector, out=np.full(min_bounds.shape, sys.float_info.max), where=np.logical_not(unit_vector==0.0))
-      # Remove negative coefficients:
+      # Remove negative and invalid coefficients:
       for i in range(3):
-         if coefficients_min[i] <= 0:
+         if coefficients_min[i] <= 0 or np.isnan(coefficients_min[i]):
             coefficients_min[i] = sys.float_info.max
-         if coefficients_max[i] <= 0:
+         if coefficients_max[i] <= 0 or np.isnan(coefficients_max[i]):
             coefficients_max[i] = sys.float_info.max
+
 
 
 
@@ -358,3 +359,206 @@ def cut_through_curve(vlsvReader, curve):
      rCoords = coords
    from output import output_1d
    return output_1d( [np.array(rCellIds, copy=False), np.array(rEdges, copy=False), np.array(rCoords, copy=False)], ["CellID", "distances", "coordinates"], ["", "m", "m"] )
+
+
+
+def get_fsgrid_indices_coordinates_distances( vlsvReader, xmax, xmin, xcells, ymax, ymin, ycells, zmax, zmin, zcells, cell_lengths, point1, point2 ):
+   ''' Calculates coordinates to be used in the fsgrid_cut_through. The coordinates are calculated so that every cell gets picked in the coordinates.
+       :param vlsvReader:       Some open VlsvReader
+       :type vlsvReader:        :class:`vlsvfile.VlsvReader`
+       :param point1:           The starting point of a cut-through line
+       :param point2:           The ending point of a cut-through line
+       :returns: Coordinates of for the cell cut-through as well as cell indices and distances
+   '''
+   from output import output_1d
+
+   point1 = np.array(point1, copy=False)
+   point2 = np.array(point2, copy=False)
+
+   distances = [0]
+
+   indices = [vlsvReader.get_fsgrid_cell_index(point1)]
+
+   coordinates = [point1]
+
+   if np.array_equal(point1,point2):
+      
+      return output_1d( [np.array(indices, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["fsgrid_cell_index", "distances", "coordinates"], ["", "m", "m"] )
+
+   epsilon = sys.float_info.epsilon*2
+
+   iterator = point1
+   unit_vector = (point2 - point1) / np.linalg.norm(point2 - point1 + epsilon)
+
+   while True:
+      # Get the cell id
+      index = vlsvReader.get_fsgrid_cell_index(iterator)
+      if index == 0:
+         print("ERROR, invalid cell id!")
+         return
+      # Get the max and min boundaries:
+      min_bounds = vlsvReader.get_fsgrid_cell_coordinates(index) - 0.5 * cell_lengths
+      max_bounds = np.array([min_bounds[i] + cell_lengths[i] for i in range(0,3)])
+      # Check which boundary we hit first when we move in the unit_vector direction:
+
+      coefficients_min = np.divide((min_bounds - iterator), unit_vector)
+      coefficients_max = np.divide((max_bounds - iterator) , unit_vector)
+      # Remove negative and invalid coefficients:
+      for i in range(3):
+         if coefficients_min[i] <= 0 or np.isnan(coefficients_min[i]):
+            coefficients_min[i] = sys.float_info.max
+         if coefficients_max[i] <= 0 or np.isnan(coefficients_max[i]):
+            coefficients_max[i] = sys.float_info.max
+
+      # Find the minimum coefficient for calculating the minimum distance from a boundary
+      coefficient = min([min(coefficients_min), min(coefficients_max)]) * 1.01
+
+      # Get the cell id in the new coordinates
+      newcoordinate = iterator + coefficient * unit_vector
+      newindex = vlsvReader.get_fsgrid_cell_index( newcoordinate )
+      # Check if valid cell id:
+      if newindex == 0:
+         break
+      # Append the cell id:
+      indices.append( newindex )
+
+
+      # Append the coordinate:
+      coordinates.append( newcoordinate )
+
+      # Append the distance:
+      distances.append( np.linalg.norm( newcoordinate - point1 ) )
+
+
+      # Move the iterator to the next cell. Note: Epsilon is here to ensure there are no bugs with float rounding
+      iterator = iterator + coefficient * unit_vector
+      # Check to make sure the iterator is not moving past point2:
+      if min((point2 - iterator)* unit_vector) < 0:
+         break
+   # Return the coordinates, cellids and distances for processing
+   return output_1d( [np.array(indices, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["fsgrid_cell_index", "distances", "coordinates"], ["", "m", "m"] )
+
+
+def fsgrid_cut_through( vlsvReader, point1, point2 ):
+   ''' Returns cell indices and distances from point 1 for every cell in a line between given point1 and point2
+
+       :param vlsvReader:       Some open VlsvReader
+       :type vlsvReader:        :class:`vlsvfile.VlsvReader`
+       :param point1:           The starting point of a cut-through line
+       :param point2:           The ending point of a cut-through line
+       :returns: an array containing cell indices, coordinates and distances in the following format: [cell indices, distances, coordinates]
+
+       .. code-block:: python
+
+          Example:
+          vlsvReader = VlsvReader(\"testfile.vlsv\")
+          fsgrid_cut_through = fsgrid_cut_through(vlsvReader, [0,0,0], [2,5e6,0])
+          indices = fsgrid_cut_through[0].data
+          distances = fsgrid_cut_through[1].data
+          print("Cell indices: " + str(indices))
+          print("Distance from point 1 for every cell: " + str(distances))
+   '''
+   # Transform point1 and point2 into numpy array:
+   point1 = np.array(point1)
+   point2 = np.array(point2)
+   # Get parameters from the file to determine a good length between points (step length):
+   # Get xmax, xmin and xcells_ini
+   mesh_limits = vlsvReader.get_fsgrid_mesh_extent()
+   mesh_size = vlsvReader.get_fsgrid_mesh_size()
+   xmax = mesh_limits[3]
+   xmin = mesh_limits[0]
+   xcells = mesh_size[0]
+   # Do the same for y
+   ymax = mesh_limits[4]
+   ymin = mesh_limits[1]
+   ycells = mesh_size[1]
+   # And for z
+   zmax = mesh_limits[5]
+   zmin = mesh_limits[2]
+   zcells = mesh_size[2]
+
+   # Make sure point1 and point2 are inside bounds
+   if vlsvReader.get_fsgrid_cell_index(point1) == 0:
+      print("ERROR, POINT1 IN CUT-THROUGH OUT OF BOUNDS!")
+   if vlsvReader.get_fsgrid_cell_index(point2) == 0:
+      print("ERROR, POINT2 IN CUT-THROUGH OUT OF BOUNDS!")
+
+   #Calculate cell lengths:
+   cell_lengths = np.array([(xmax - xmin)/(float)(xcells), (ymax - ymin)/(float)(ycells), (zmax - zmin)/(float)(zcells)])
+
+   # Get list of coordinates for the cells:
+   return get_fsgrid_indices_coordinates_distances( vlsvReader, xmax, xmin, xcells, ymax, ymin, ycells, zmax, zmin, zcells, cell_lengths, point1, point2 )
+
+
+
+
+def fsgrid_cut_through_step( vlsvReader, point1, point2 ):
+   ''' Returns cell indices and distances from point 1 to point 2, returning not every cell in a line
+       but rather the amount of cells which correspons with the largest axis-aligned component of the line.
+
+       :param vlsvReader:       Some open VlsvReader
+       :type vlsvReader:        :class:`vlsvfile.VlsvReader`
+       :param point1:           The starting point of a cut-through line
+       :param point2:           The ending point of a cut-through line
+       :returns: an array containing cell indices, coordinates and distances in the following format: [cell indices, distances, coordinates]
+
+       .. code-block:: python
+
+          Example:
+          vlsvReader = VlsvReader(\"testfile.vlsv\")
+          fsgrid_cut_through = fsgrid_cut_through_step(vlsvReader, [0,0,0], [2,5e6,0])
+          indices = fsgrid_cut_through[0].data
+          distances = fsgrid_cut_through[1].data
+          print("Cell indices: " + str(indices))
+          print("Distance from point 1 for every cell: " + str(distances))
+   '''
+   # Transform point1 and point2 into numpy array:
+   point1 = np.array(point1)
+   point2 = np.array(point2)
+
+   # Make sure point1 and point2 are inside bounds
+   if vlsvReader.get_fsgrid_cell_index(point1) == 0:
+      print("ERROR, POINT1 IN CUT-THROUGH OUT OF BOUNDS!")
+   if vlsvReader.get_fsgrid_cell_index(point2) == 0:
+      print("ERROR, POINT2 IN CUT-THROUGH OUT OF BOUNDS!")
+   
+   # Find path
+   distances = point2-point1
+   largestdistance = np.linalg.norm(distances)
+   largestindex = np.argmax(abs(distances))
+   derivative = distances/abs(distances[largestindex])
+
+
+
+   # Get parameters from the file to determine a good length between points (step length):
+   # Get xmax, xmin and xcells_ini   
+   [xcells, ycells, zcells] = vlsvReader.get_fsgrid_mesh_size()
+   [xmin, ymin, zmin, xmax, ymax, zmax] = vlsvReader.get_fsgrid_mesh_extent()
+
+   # Calculate cell lengths:
+   cell_lengths = np.array([(xmax - xmin)/(float)(xcells), (ymax - ymin)/(float)(ycells), (zmax - zmin)/(float)(zcells)])
+
+
+   # Initialize lists
+   distances = [0]
+   indices = [vlsvReader.get_fsgrid_cell_index(point1)]
+   coordinates = [point1]
+   finalindex = vlsvReader.get_fsgrid_cell_index(point2)
+
+   # Loop until final cellid is reached
+   while True:
+      newcoordinate = coordinates[-1]+cell_lengths*derivative
+      newindex = vlsvReader.get_fsgrid_cell_index( newcoordinate )
+
+      distances.append( np.linalg.norm( newcoordinate - point1 ) )
+      coordinates.append(newcoordinate)
+      indices.append(newindex)
+
+      if newindex==finalindex:
+         break
+      if distances[-1]>largestdistance:
+         break
+      
+   # Return the coordinates, cellids and distances for processing
+   from output import output_1d
+   return output_1d( [np.array(indices, copy=False), np.array(distances, copy=False), np.array(coordinates, copy=False)], ["fsgrid_cell_index", "distances", "coordinates"], ["", "m", "m"] )

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -127,6 +127,46 @@ class VlsvReader(object):
       self.__dy = (self.__ymax - self.__ymin) / (float)(self.__ycells)
       self.__dz = (self.__zmax - self.__zmin) / (float)(self.__zcells)
 
+
+
+      self.__fs_fileindex_for_cell_index={}
+      meshName='fsgrid'
+      fs_bbox = self.read(tag="MESH_BBOX", mesh=meshName)
+      if fs_bbox is None:
+         #read in older vlsv files where the mesh is defined with parameters
+         self.__fs_xcells = (int)(self.read_parameter("xcells_ini"))
+         self.__fs_ycells = (int)(self.read_parameter("ycells_ini"))
+         self.__fs_zcells = (int)(self.read_parameter("zcells_ini"))
+         self.__fs_xblock_size = 1
+         self.__fs_yblock_size = 1
+         self.__fs_zblock_size = 1
+         self.__fs_xmin = self.read_parameter("xmin")
+         self.__fs_ymin = self.read_parameter("ymin")
+         self.__fs_zmin = self.read_parameter("zmin")
+         self.__fs_xmax = self.read_parameter("xmax")
+         self.__fs_ymax = self.read_parameter("ymax")
+         self.__fs_zmax = self.read_parameter("zmax")
+      else:
+         #new style vlsv file with 
+         nodeCoordinatesX = self.read(tag="MESH_NODE_CRDS_X", mesh=meshName)   
+         nodeCoordinatesY = self.read(tag="MESH_NODE_CRDS_Y", mesh=meshName)   
+         nodeCoordinatesZ = self.read(tag="MESH_NODE_CRDS_Z", mesh=meshName)   
+         self.__fs_xcells = fs_bbox[0]
+         self.__fs_ycells = fs_bbox[1]
+         self.__fs_zcells = fs_bbox[2]
+         self.__fs_xblock_size = fs_bbox[3]
+         self.__fs_yblock_size = fs_bbox[4]
+         self.__fs_zblock_size = fs_bbox[5]
+         self.__fs_xmin = nodeCoordinatesX[0]
+         self.__fs_ymin = nodeCoordinatesY[0]
+         self.__fs_zmin = nodeCoordinatesZ[0]
+         self.__fs_xmax = nodeCoordinatesX[-1]
+         self.__fs_ymax = nodeCoordinatesY[-1]
+         self.__fs_zmax = nodeCoordinatesZ[-1]
+
+      self.__fs_dx = (self.__fs_xmax - self.__fs_xmin) / (float)(self.__fs_xcells)
+      self.__fs_dy = (self.__fs_ymax - self.__fs_ymin) / (float)(self.__fs_ycells)
+      self.__fs_dz = (self.__fs_zmax - self.__fs_zmin) / (float)(self.__fs_zcells)
       self.__meshes = {}
 
       # Iterate through the XML tree, find all populations


### PR DESCRIPTION
Corrected a bug where cut_through wouldn't give an answer if the x coordinates of both end points were 0.
Added functions fsgrid_cut_through and fsgrid_cut_through_step.
Added methods for finding coordinates for FSGrid cell indices and vice versa, and for moving from CellIDs to FSGrid's cell indices.