### PR TITLE
Vlsv postprocessor2

### DIFF
--- a/examples/sidecar.py
+++ b/examples/sidecar.py
@@ -1,0 +1,95 @@
+# This file is part of Analysator.
+# Copyright 2013-2016 Finnish Meteorological Institute
+# Copyright 2017-2022 University of Helsinki
+# 
+# For details of usage, see the COPYING file and read the "Rules of the Road"
+# at http://www.physics.helsinki.fi/vlasiator/
+# 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# 
+
+
+# This file contains an example on how to use the vlsvReader and vlsvWriter
+# functionalities to derive quantities (especially differential operations 
+# on an AMR mesh via uniform grid resampling) from .vlsv variables and store
+# them to a sidecar file AMR grid.
+#
+# The file first defines a reader for input data and a writer for the output,
+# and copies over a list of variables desired for the output (CellID is 
+# definitely worth copying over). A definition for curl on fsgrid is given,
+# after which fg_b (a face-centered field) is re-centered as volumetric. J is
+# then calculated on fsgrid from the volumetric B, which is then downsampled 
+# onto SpatialGrid via averaging and written into the sidecar file.
+#
+# A Script like this can be adapter for personal use, and
+# passed to a job submission system for generating a multitude of sidecars
+# via e.g. array jobs.
+
+import pytools as pt
+import numpy as np
+
+q = 1.60217662e-19
+me = 9.10938356e-31
+mp = 1.6726219e-27
+eps0 = 8.854e-12 
+
+import time
+
+# Change filenames and paths to your liking
+fn = 'bulk1.0001450.vlsv'
+f = pt.vlsvfile.VlsvReader(fn)
+writer = pt.vlsvfile.VlsvWriter(f, 'pysidecar_bulk1.0001450.vlsv')
+
+print(f.get_all_variables())
+print(f)
+cellIds=f.read_variable("CellID")
+argsorti=f.read_variable("CellID").argsort()
+
+
+fgsize=f.get_fsgrid_mesh_size()
+fgext=f.get_fsgrid_mesh_extent()
+t = time.time()
+print("copy_var_list")
+writer.copy_variables_list(f, ["CellID"])
+print('writer init and var copy, elapsed:', time.time()-t)
+
+
+def fg_vol_curl(reader, array):
+   dx = reader.get_fsgrid_cell_size()
+   dummy,  dFx_dy, dFx_dz = np.gradient(array[:,:,:,0], *dx)
+   dFy_dx, dummy,  dFy_dz = np.gradient(array[:,:,:,1], *dx)
+   dFz_dx, dFz_dy, dummy  = np.gradient(array[:,:,:,2], *dx)
+
+   rotx = dFz_dy - dFy_dz
+   roty = dFx_dz - dFz_dx
+   rotz = dFy_dx - dFx_dy
+
+   return np.stack([rotx, roty, rotz], axis=-1)
+
+print('Processing for J, elapsed', time.time()-t)
+fg_b_vol=f.read_fg_variable_as_volumetric('fg_b')
+print('fgbvol read, shape ', fg_b_vol.shape, 'elapsed:', time.time()-t)
+
+fg_J = fg_vol_curl(f, fg_b_vol)/1.25663706144e-6
+print('fgbvol curled, elapsed:', time.time()-t)
+
+f.map_vg_onto_fg()
+print('vg mapped to fg, elapsed:', time.time()-t)
+
+vg_J = f.fsgrid_array_to_vg(fg_J)
+print('fg_J mapped to vg, elapsed:', time.time()-t)
+
+writer.write(vg_J,'vg_J','VARIABLE','SpatialGrid')
+print('J written, elapsed:', time.time()-t)

--- a/examples/sidecar.py
+++ b/examples/sidecar.py
@@ -48,7 +48,7 @@ eps0 = 8.854e-12
 import time
 
 # Change filenames and paths to your liking
-fn = 'bulk1.0001450.vlsv'
+fn = '/wrk-vakka/group/spacephysics/vlasiator/3D/EGI/bulk/dense_cold_hall1e5_afterRestart374/bulk1.0001450.vlsv'
 f = pt.vlsvfile.VlsvReader(fn)
 writer = pt.vlsvfile.VlsvWriter(f, 'pysidecar_bulk1.0001450.vlsv')
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1306,7 +1306,6 @@ class VlsvReader(object):
          singletons = [i for i, sz in enumerate(fssize) if sz == 1]
          for dim in singletons:
             fgdata=np.expand_dims(fgdata, dim)
-      #print('read in fgdata with shape', fgdata.shape, name)
       celldata = np.zeros_like(fgdata)
       known_centerings = {"fg_b":"face", "fg_e":"edge"}
       if centering is None:
@@ -1503,7 +1502,6 @@ class VlsvReader(object):
       
       hdx = self.get_cell_dx(cellid)*0.5
       mid = self.get_cell_coordinates(cellid)
-      #print('halfdx:', hdx, 'mid:', mid, 'low:', mid-hdx, 'hi:', mid+hdx)
       return mid-hdx, mid+hdx
 
    def get_cell_fsgrid_slicemap(self, cellid):
@@ -1525,7 +1523,6 @@ class VlsvReader(object):
       covered by the SpatialGrid cellid.
       '''
       lowi, upi = self.get_cell_fsgrid_slicemap(cellid)
-      #print('subarray:',lowi, upi)
       if array.ndim == 4:
          return array[lowi[0]:upi[0]+1, lowi[1]:upi[1]+1, lowi[2]:upi[2]+1, :]
       else:
@@ -1535,7 +1532,6 @@ class VlsvReader(object):
       '''Returns a subarray of the fsgrid array, corresponding to the (low, up) bounding box.
       '''
       lowi, upi = self.get_bbox_fsgrid_slicemap(low,up)
-      #print('subarray:',lowi, upi)
       if array.ndim == 4:
          return array[lowi[0]:upi[0]+1, lowi[1]:upi[1]+1, lowi[2]:upi[2]+1, :]
       else:
@@ -1593,12 +1589,9 @@ class VlsvReader(object):
       cellid. Mutator for array.
       '''
       lowi, upi = self.get_cell_fsgrid_slicemap(cellid)
-      #print(lowi,upi)
       value = self.read_variable(var, cellids=[cellid])
       if array.ndim == 4:
-         #print(value)
          array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1,:] = value
-         #print(array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1,:])
       else:
          array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1] = value
       return

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1591,19 +1591,31 @@ class VlsvReader(object):
       return
 
    def read_variable_as_fg(self, var):
-      cellids = self.read_variable('CellID')
+      vg_cellids = self.read_variable('CellID')
       sz = self.get_fsgrid_mesh_size()
-      testvar = self.read_variable(var, [cellids[0]])
-      varsize = testvar.size
+      sz_amr = self.get_spatial_mesh_size()
+      vg_var = self.read_variable(var)
+      varsize = vg_var[0].size
       if(varsize > 1):
-         fgarr = np.zeros([sz[0], sz[1], sz[2], varsize], dtype=testvar.dtype)
+         fg_var = np.zeros([sz[0], sz[1], sz[2], varsize], dtype=vg_var.dtype)
       else:
-         fgarr = np.zeros(sz, dtype=testvar.dtype)
-      for c in cellids:
-         self.upsample_fsgrid_subarray(c, var, fgarr)
-         #print
-      return fgarr
-
+         fg_var = np.zeros(sz, dtype=vg_var.dtype)
+      vg_cellids_on_fg = np.zeros(sz, dtype=np.int64) + 1000000000 # big number to catch errors in the latter code, 0 is not good for that
+      current_amr_level = self.get_amr_level(np.min(vg_cellids))
+      max_amr_level = int(np.log2(sz[0] / sz_amr[0]))
+      current_max_cellid = 0
+      for level in range(current_amr_level+1):
+         current_max_cellid += 2**(3*(level))*(self.__xcells*self.__ycells*self.__zcells)
+      for id in np.argsort(vg_cellids):
+         if vg_cellids[id] > current_max_cellid:
+            current_amr_level += 1
+            current_max_cellid += 2**(3*(current_amr_level))*(self.__xcells*self.__ycells*self.__zcells)
+         this_cell_indices = np.array(self.get_cell_indices(vg_cellids[id], current_amr_level), dtype=np.int64)
+         refined_ids_start = this_cell_indices * 2**(max_amr_level-current_amr_level)
+         refined_ids_end = refined_ids_start + 2**(max_amr_level-current_amr_level)
+         vg_cellids_on_fg[refined_ids_start[0]:refined_ids_end[0],refined_ids_start[1]:refined_ids_end[1],refined_ids_start[2]:refined_ids_e>
+      fg_var = vg_var[vg_cellids_on_fg]
+      return fg_var
 
    def get_cell_fsgrid(self, cellid):
       '''Returns a slice tuple of fsgrid indices that are contained in the SpatialGrid

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1613,7 +1613,7 @@ class VlsvReader(object):
          this_cell_indices = np.array(self.get_cell_indices(vg_cellids[id], current_amr_level), dtype=np.int64)
          refined_ids_start = this_cell_indices * 2**(max_amr_level-current_amr_level)
          refined_ids_end = refined_ids_start + 2**(max_amr_level-current_amr_level)
-         vg_cellids_on_fg[refined_ids_start[0]:refined_ids_end[0],refined_ids_start[1]:refined_ids_end[1],refined_ids_start[2]:refined_ids_e>
+         vg_cellids_on_fg[refined_ids_start[0]:refined_ids_end[0],refined_ids_start[1]:refined_ids_end[1],refined_ids_start[2]:refined_ids_end[2]] = id
       fg_var = vg_var[vg_cellids_on_fg]
       return fg_var
 

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -39,8 +39,11 @@ class VlsvWriter(object):
           :param file_name:     Name of the vlsv file where to input data
       '''
       self.file_name = os.path.abspath(file_name)
-      self.__fptr = open(self.file_name,"wb")
-
+      try:
+         self.__fptr = open(self.file_name,"wb")
+      except FileNotFoundError as e:
+         print("No such path: ", self.file_name)
+         raise e
       self.__xml_root = ET.fromstring("<VLSV></VLSV>")
       self.__fileindex_for_cellid={}
 
@@ -67,6 +70,8 @@ class VlsvWriter(object):
       tags['MESH_NODE_CRDS_Z'] = ''
       tags['MESH'] = ''
       tags['MESH_DOMAIN_SIZES'] = ''
+      tags['MESH_GHOST_DOMAINS'] = ''
+      tags['MESH_GHOST_LOCALIDS'] = ''
       tags['CellID'] = ''
       tags['MESH_BBOX'] = ''
       tags['COORDS'] = ''
@@ -77,7 +82,7 @@ class VlsvWriter(object):
             if 'name' in child.attrib: name = child.attrib['name']
             else: name = ''
             if 'mesh' in child.attrib: mesh = child.attrib['mesh']
-            else: mesh = ''
+            else: mesh = None
             tag = child.tag
             extra_attribs = {}
             for i in child.attrib.items():
@@ -88,10 +93,15 @@ class VlsvWriter(object):
             self.write( data=data, name=name, tag=tag, mesh=mesh, extra_attribs=extra_attribs )
 
 
-   def copy_variables( self, vlsvReader ):
-      ''' Copies all variables from vlsv reader to the file
-
+   def copy_variables( self, vlsvReader, varlist=None ):
+      ''' Copies variables from vlsv reader to the file.
+           varlist = None: list of variables to copy; 
       '''
+
+      # Delegate to the variable list handler
+      if (varlist is not None):
+         self.copy_variables_list(vlsvReader, varlist)
+
       # Get the xml sheet:
       xml_root = vlsvReader._VlsvReader__xml_root
 
@@ -110,6 +120,44 @@ class VlsvWriter(object):
                 mesh = child.attrib['mesh']
             else:
                 mesh = ''
+            tag = child.tag
+            # Copy extra attributes:
+            extra_attribs = {}
+            for i in child.attrib.items():
+               if i[0] != 'name' and i[0] != 'mesh':
+                  extra_attribs[i[0]] = i[1]
+            data = vlsvReader.read( name=name, tag=tag, mesh=mesh )
+            # Write the data:
+            self.write( data=data, name=name, tag=tag, mesh=mesh, extra_attribs=extra_attribs )
+      return
+
+   def copy_variables_list( self, vlsvReader, vars ):
+      ''' Copies variables in the list vars from vlsv reader to the file
+
+      '''
+      # Get the xml sheet:
+      xml_root = vlsvReader._VlsvReader__xml_root
+
+      # Get list of tags to write:
+      tags = {}
+      tags['VARIABLE'] = ''
+
+      # Copy the xml root and write variables
+      for child in xml_root:
+         if child.tag in tags:
+            if 'name' in child.attrib:
+                name = child.attrib['name']
+                if not name in vars:
+                   continue
+            else:
+                continue
+            if 'mesh' in child.attrib:
+                mesh = child.attrib['mesh']
+            else:
+               if tag in ['VARIABLE']:
+                  print('MESH required')
+                  return
+               mesh = None
             tag = child.tag
             # Copy extra attributes:
             extra_attribs = {}
@@ -162,7 +210,8 @@ class VlsvWriter(object):
       # Add the data into the xml data:
       child = ET.SubElement(parent=self.__xml_root, tag=tag)
       child.attrib["name"] = name
-      child.attrib["mesh"] = mesh
+      if mesh is not None:
+         child.attrib["mesh"] = mesh
       child.attrib["arraysize"] = len(np.atleast_1d(data))
       if extra_attribs != '':
          for i in extra_attribs.items():
@@ -175,7 +224,14 @@ class VlsvWriter(object):
          return False
       else:
          child.attrib["vectorsize"] = 1
-         datatype = str(type(data[0]))
+         if(len(data) == 0):
+            if tag=="MESH_GHOST_DOMAINS" or tag=="MESH_GHOST_LOCALIDS":
+               datatype="int32"
+            else:
+               print("Trying to extract datatype from an empty array. I will fail as usual, since this is not the special case that is guarded against!")
+               datatype = str(type(data[0]))
+         else:
+            datatype = str(type(data[0]))
 
       # Parse the data types:
       if 'uint' in datatype:
@@ -185,7 +241,7 @@ class VlsvWriter(object):
       elif 'float' in datatype:
          child.attrib["datatype"] = "float"
       else:
-         print("BAD DATATYPE")
+         print("BAD DATATYPE: " + datatype)
          return False
 
       if '64' in datatype:
@@ -205,6 +261,34 @@ class VlsvWriter(object):
       # write the xml footer:
       self.__write_xml_footer()
 
+   def write_variable(self, data, name, mesh, variableLaTex, unit, unitLaTeX, unitConversion, extra_attribs={}):
+      ''' Writes an array into the vlsv file as a variable; requires input of metadata required by VlsvReader
+
+      :param name: Name of the data array
+      :param mesh: Mesh for the data array
+      :param variableLaTeX: LaTeX string representation of variable
+      :param unit: plaintext string represenation of the unit
+      :param unitLaTeX: LaTeX string represenation of the unit
+      :param unitConversion: string represenation of the unit conversion to get to SI
+      :param extra_attribs: Dictionary with whatever xml attributes that should be defined in the array that aren't name, tag, or mesh
+
+      :returns: True if the data was written successfully
+
+      '''
+
+      return self.write(data, name, 'VARIABLE', mesh, extra_attribs={'variableLaTeX':variableLaTex, 'unit':unit, 'unitLaTeX':unitLaTeX, 'unitConversion':unitConversion})
+
+
+   def write_fgarray_to_SpatialGrid(self, reader, data, name, extra_attribs={}):
+      # get a reader for the target file
+      #print(data.shape[0:3], reader.get_fsgrid_mesh_size(), (data.shape[0:3] == reader.get_fsgrid_mesh_size()))
+      if not (data.shape[0:3] == reader.get_fsgrid_mesh_size()).all():
+         print("Data shape does not match target fsgrid mesh")
+         return
+      cids = reader.read_variable("CellID")
+      vgdata = [reader.downsample_fsgrid_subarray(cid, data) for cid in cids]
+      self.write(vgdata, name, "VARIABLE", "SpatialGrid",extra_attribs)
+
    def __write_xml_footer( self ):
       # Write the xml footer:
       max_xml_size = 1000000
@@ -219,6 +303,7 @@ class VlsvWriter(object):
          for i in child.attrib.items():
             child.attrib[i[0]] = str(child.attrib[i[0]])
       tree = ET.ElementTree( self.__xml_root)
+      xml_footer_indent( self.__xml_root)
       tree.write(fptr)
       # Write the offset (first 8 bytes = endianness):
       offset_endianness = 8
@@ -232,3 +317,17 @@ class VlsvWriter(object):
       self.__write_xml_footer()
       self.__fptr.close()
 
+def xml_footer_indent(elem, level=0):
+   i = "\n" + level*"   "
+   if len(elem):
+      if not elem.text or not elem.text.strip():
+            elem.text = i + "   "
+      if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+      for elem in elem:
+            xml_footer_indent(elem, level+1)
+      if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+   else:
+      if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -285,8 +285,7 @@ class VlsvWriter(object):
       if not (data.shape[0:3] == reader.get_fsgrid_mesh_size()).all():
          print("Data shape does not match target fsgrid mesh")
          return
-      cids = reader.read_variable("CellID")
-      vgdata = [reader.downsample_fsgrid_subarray(cid, data) for cid in cids]
+      vgdata = reader.fsgrid_array_to_vg(data)
       self.write(vgdata, name, "VARIABLE", "SpatialGrid",extra_attribs)
 
    def __write_xml_footer( self ):

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -208,7 +208,7 @@ class VlsvWriter(object):
       datatype = ''
 
       # Add the data into the xml data:
-      child = ET.SubElement(parent=self.__xml_root, tag=tag)
+      child = ET.SubElement(self.__xml_root, tag)
       child.attrib["name"] = name
       if mesh is not None:
          child.attrib["mesh"] = mesh

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -279,9 +279,9 @@ class VlsvWriter(object):
    def write_variable_info(self, varinfo, mesh, unitConversion, extra_attribs={}):
       ''' Writes an array into the vlsv file as a variable; requires input of metadata required by VlsvReader
       :param varinfo: VariableInfo object containing
+         -data: The variable data (array)
          -name: Name of the data array
          -latex: LaTeX string representation of the variable name
-         -variableLaTeX: LaTeX string representation of variable
          -units: plaintext string represenation of the unit
          -latexunits: LaTeX string represenation of the unit
       :param mesh: Mesh for the data array

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -276,7 +276,7 @@ class VlsvWriter(object):
       # write the xml footer:
       self.__write_xml_footer()
 
-   def write_variable(self, varinfo, mesh, unitConversion, extra_attribs={}):
+   def write_variable_info(self, varinfo, mesh, unitConversion, extra_attribs={}):
       ''' Writes an array into the vlsv file as a variable; requires input of metadata required by VlsvReader
       :param varinfo: VariableInfo object containing
          -name: Name of the data array

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -101,6 +101,7 @@ class VlsvWriter(object):
       # Delegate to the variable list handler
       if (varlist is not None):
          self.copy_variables_list(vlsvReader, varlist)
+         return
 
       # Get the xml sheet:
       xml_root = vlsvReader._VlsvReader__xml_root

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -106,7 +106,8 @@ class VlsvWriter(object):
 
    def copy_variables( self, vlsvReader, varlist=None ):
       ''' Copies variables from vlsv reader to the file.
-           varlist = None: list of variables to copy; 
+           varlist = None: list of variables to copy; if no
+           varlist is provided, copy all variables (default)
       '''
 
       # Delegate to the variable list handler
@@ -131,7 +132,7 @@ class VlsvWriter(object):
             if 'mesh' in child.attrib:
                 mesh = child.attrib['mesh']
             else:
-                mesh = ''
+                mesh = None
             tag = child.tag
             # Copy extra attributes:
             extra_attribs = {}
@@ -275,22 +276,24 @@ class VlsvWriter(object):
       # write the xml footer:
       self.__write_xml_footer()
 
-   def write_variable(self, data, name, mesh, variableLaTex, unit, unitLaTeX, unitConversion, extra_attribs={}):
+   def write_variable(self, varinfo, mesh, unitConversion, extra_attribs={}):
       ''' Writes an array into the vlsv file as a variable; requires input of metadata required by VlsvReader
-
-      :param name: Name of the data array
+      :param varinfo: VariableInfo object containing
+         -name: Name of the data array
+         -latex: LaTeX string representation of the variable name
+         -variableLaTeX: LaTeX string representation of variable
+         -units: plaintext string represenation of the unit
+         -latexunits: LaTeX string represenation of the unit
       :param mesh: Mesh for the data array
-      :param variableLaTeX: LaTeX string representation of variable
-      :param unit: plaintext string represenation of the unit
-      :param unitLaTeX: LaTeX string represenation of the unit
       :param unitConversion: string represenation of the unit conversion to get to SI
-      :param extra_attribs: Dictionary with whatever xml attributes that should be defined in the array that aren't name, tag, or mesh
+      :param extra_attribs: Dictionary with whatever xml attributes that should be defined in the array that aren't name, tag, or mesh,
+        or contained in varinfo. Can be used to overwrite varinfo values besids name.
 
       :returns: True if the data was written successfully
 
       '''
 
-      return self.write(data, name, 'VARIABLE', mesh, extra_attribs={'variableLaTeX':variableLaTex, 'unit':unit, 'unitLaTeX':unitLaTeX, 'unitConversion':unitConversion})
+      return self.write(varinfo.data, varinfo.name, 'VARIABLE', mesh, extra_attribs={'variableLaTeX':varinfo.latex, 'unit':varinfo.units, 'unitLaTeX':varinfo.latexunits, 'unitConversion':unitConversion}.update(extra_attribs))
 
 
    def write_fgarray_to_SpatialGrid(self, reader, data, name, extra_attribs={}):


### PR DESCRIPTION
Sidecar postprocessing for analysator, with an example script to calculate J in EGI.
Helpers, fixes from vlsvPostprocessing branch now in a format that does not remove ionosphere additions, for whatever reason. Includes Yann's optimization for fsgrid-SpatialGrid mapping, which is here adapted to be cached for successive calls.