### PR TITLE
vlsvReader improvements

### DIFF
--- a/pyVlsv/reducer.py
+++ b/pyVlsv/reducer.py
@@ -30,8 +30,9 @@ class DataReducerVariable:
    latex = ""
    latexunits = ""
    useVspace = False
+   useReader = False
    vector_size=1
-   def __init__(self, variables, operation, units, vector_size, latex="", latexunits="",useVspace=False):
+   def __init__(self, variables, operation, units, vector_size, latex="", latexunits="",useVspace=False,useReader=False):
       ''' Constructor for the class
           :param variables          List of variables for doing calculations with
           :param operation          The operation (function) that operates on the variables
@@ -53,4 +54,5 @@ class DataReducerVariable:
       self.latex = latex
       self.latexunits = latexunits
       self.useVspace = useVspace
+      self.useReader = useReader
 

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -694,25 +694,17 @@ def firstadiabatic( variables ):
 
 def vg_coordinates_cellcenter( variables, reader):
    cellids = variables[0]
-   if not hasattr(cellids,"__len__"): # single cell
-      return reader.get_cell_coordinates(cellids)
-   else: # list of cellids
-      return reader.get_cells_coordinates(cellids)
+   return reader.get_cell_coordinates(cellids)
 
 def vg_coordinates_lowcorner( variables, reader):
    cellids = variables[0]
    dxs = variables[1]
-   if not hasattr(cellids,"__len__"): # single cell
-      return reader.get_cell_coordinates(cellids)-dxs/2
-   else: # list of cellids
-      return reader.get_cells_coordinates(cellids)-dxs/2
+   return reader.get_cell_coordinates(cellids)-dxs/2
 
 def vg_dx(variables, reader):
    cellids = variables[0]
-   if not hasattr(cellids,"__len__"): # single cell
-      return reader.get_cell_dx(cellids)
-   else: # list of cellids
-      return reader.get_cell_dxs(cellids)
+   return reader.get_cell_dx(cellids)
+
 
 #list of operators. The user can apply these to any variable,
 #including more general datareducers. Can only be used to reduce one

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -692,6 +692,20 @@ def firstadiabatic( variables ):
    B = np.ma.masked_less_equal(np.ma.masked_invalid(B),0)
    return np.ma.divide(Tperp,B)
 
+def vg_cellcenter_coordinates( variables, reader):
+   cellids = variables[0]
+   if not hasattr(cellids,"__len__"): # single cell
+      return reader.get_cell_coordinates(cellids)
+   else: # list of cellids
+      return(reader.get_cells_coordinates(cellids))
+
+def vg_dx(variables, reader):
+   cellids = variables[0]
+   if not hasattr(cellids,"__len__"): # single cell
+      return reader.get_cell_dx(cellids)
+   else: # list of cellids
+      return reader.get_cell_dxs(cellids)
+
 #list of operators. The user can apply these to any variable,
 #including more general datareducers. Can only be used to reduce one
 #variable at a time
@@ -1003,6 +1017,13 @@ v5reducers["vg_restart_v"] =              DataReducerVariable(["moments"], resta
 v5reducers["vg_restart_rho"] =            DataReducerVariable(["moments"], restart_rho, "1/m3", 1, latex=r"$n_\mathrm{p}$",latexunits=r"$\mathrm{m}^{-3}$")
 v5reducers["vg_restart_rhom"] =           DataReducerVariable(["moments"], restart_rhom, "kg/m3", 1, latex=r"$\rho_m$",latexunits=r"$\mathrm{kg}\,\mathrm{m}^{-3}$")
 v5reducers["vg_restart_rhoq"] =           DataReducerVariable(["moments"], restart_rhoq, "C/m3", 1, latex=r"$\rho_q$",latexunits=r"$\mathrm{C}\,\mathrm{m}^{-3}$")
+
+v5reducers["vg_coordinates"] =            DataReducerVariable(["CellID"], vg_cellcenter_coordinates, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_coordinates_cellcenter"] =            DataReducerVariable(["CellID"], vg_cellcenter_coordinates, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+
+v5reducers["vg_dx"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_dxs"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)
+
 
 
 #multipopv5reducers

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -692,7 +692,7 @@ def firstadiabatic( variables ):
    B = np.ma.masked_less_equal(np.ma.masked_invalid(B),0)
    return np.ma.divide(Tperp,B)
 
-def vg_cellcenter_coordinates( variables, reader):
+def vg_coordinates_cellcenter( variables, reader):
    cellids = variables[0]
    if not hasattr(cellids,"__len__"): # single cell
       return reader.get_cell_coordinates(cellids)
@@ -1018,8 +1018,8 @@ v5reducers["vg_restart_rho"] =            DataReducerVariable(["moments"], resta
 v5reducers["vg_restart_rhom"] =           DataReducerVariable(["moments"], restart_rhom, "kg/m3", 1, latex=r"$\rho_m$",latexunits=r"$\mathrm{kg}\,\mathrm{m}^{-3}$")
 v5reducers["vg_restart_rhoq"] =           DataReducerVariable(["moments"], restart_rhoq, "C/m3", 1, latex=r"$\rho_q$",latexunits=r"$\mathrm{C}\,\mathrm{m}^{-3}$")
 
-v5reducers["vg_coordinates"] =            DataReducerVariable(["CellID"], vg_cellcenter_coordinates, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
-v5reducers["vg_coordinates_cellcenter"] =            DataReducerVariable(["CellID"], vg_cellcenter_coordinates, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_coordinates"] =            DataReducerVariable(["CellID"], vg_coordinates_cellcenter, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_coordinates_cellcenter"] =            DataReducerVariable(["CellID"], vg_coordinates_cellcenter, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
 
 v5reducers["vg_dx"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)
 v5reducers["vg_dxs"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -697,7 +697,15 @@ def vg_coordinates_cellcenter( variables, reader):
    if not hasattr(cellids,"__len__"): # single cell
       return reader.get_cell_coordinates(cellids)
    else: # list of cellids
-      return(reader.get_cells_coordinates(cellids))
+      return reader.get_cells_coordinates(cellids)
+
+def vg_coordinates_lowcorner( variables, reader):
+   cellids = variables[0]
+   dxs = variables[1]
+   if not hasattr(cellids,"__len__"): # single cell
+      return reader.get_cell_coordinates(cellids)-dxs/2
+   else: # list of cellids
+      return reader.get_cells_coordinates(cellids)-dxs/2
 
 def vg_dx(variables, reader):
    cellids = variables[0]
@@ -1019,7 +1027,9 @@ v5reducers["vg_restart_rhom"] =           DataReducerVariable(["moments"], resta
 v5reducers["vg_restart_rhoq"] =           DataReducerVariable(["moments"], restart_rhoq, "C/m3", 1, latex=r"$\rho_q$",latexunits=r"$\mathrm{C}\,\mathrm{m}^{-3}$")
 
 v5reducers["vg_coordinates"] =            DataReducerVariable(["CellID"], vg_coordinates_cellcenter, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
-v5reducers["vg_coordinates_cellcenter"] =            DataReducerVariable(["CellID"], vg_coordinates_cellcenter, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_coordinates_cell_center"] =            DataReducerVariable(["CellID"], vg_coordinates_cellcenter, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+v5reducers["vg_coordinates_cell_lowcorner"] =            DataReducerVariable(["CellID","vg_dxs"], vg_coordinates_lowcorner, "m", 3, latex=r"$\vec{r}_\mathrm{cc}$", latexunits=r"$\mathrm{m}$", useReader=True)
+
 
 v5reducers["vg_dx"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)
 v5reducers["vg_dxs"] =            DataReducerVariable(["CellID"], vg_dx, "m", 3, latex=r"$\Delta{}\vec{r}$", latexunits=r"$\mathrm{m}$", useReader=True)

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -689,7 +689,8 @@ class VlsvReader(object):
       .. seealso:: :func:`read_variable` :func:`read_variable_info`
       '''
       if tag == "" and name == "":
-         print("Bad arguments at read")
+         print("Bad (empty) arguments at VlsvReader.read")
+         raise ValueError()
 
       # Force lowercase name for internal checks
       name = name.lower()
@@ -1537,24 +1538,29 @@ class VlsvReader(object):
          self.__max_spatial_amr_level = AMR_count - 1
       return self.__max_spatial_amr_level
       
+   # def get_amr_level(self,cellid):
+   #    '''Returns the AMR level of a given cell defined by its cellid
+      
+   #    :param cellid:        The cell's cellid
+   #    :returns:             The cell's refinement level in the AMR
+   #    '''
+   #    AMR_count = 0
+   #    while (cellid > 0):
+   #       cellid -= 2**(3*(AMR_count))*(self.__xcells*self.__ycells*self.__zcells)
+   #       AMR_count += 1
+   #    return AMR_count - 1 
+
    def get_amr_level(self,cellid):
       '''Returns the AMR level of a given cell defined by its cellid
       
       :param cellid:        The cell's cellid
       :returns:             The cell's refinement level in the AMR
       '''
-      AMR_count = 0
-      while (cellid > 0):
-         cellid -= 2**(3*(AMR_count))*(self.__xcells*self.__ycells*self.__zcells)
-         AMR_count += 1
-      return AMR_count - 1 
+      stack = True
+      if not hasattr(cellid,"__len__"):
+         cellid = np.atleast_1d(cellid)
+         stack = False
 
-   def get_amr_levels(self,cellid):
-      '''Returns the AMR level of a given cell defined by its cellid
-      
-      :param cellid:        The cell's cellid
-      :returns:             The cell's refinement level in the AMR
-      '''
       AMR_count = np.zeros(np.array(cellid).shape, dtype=np.int64)
       cellids = cellid.astype(np.int64)
       iters = 0
@@ -1567,7 +1573,11 @@ class VlsvReader(object):
          if(iters > self.get_max_refinement_level()+1):
             print("Can't have that large refinements. Something broke.")
             break
-      return AMR_count - 1 
+
+      if stack:
+         return AMR_count - 1 
+      else:
+         return (AMR_count - 1)[0]
 
    def get_cell_dx(self, cellid):
       '''Returns the dx of a given cell defined by its cellid
@@ -1575,25 +1585,25 @@ class VlsvReader(object):
       :param cellid:        The cell's cellid
       :returns:             The cell's size [dx, dy, dz]
       '''
-      return np.array([self.__dx,self.__dy,self.__dz])/2**self.get_amr_level(cellid)
 
-   def get_cell_dxs(self, cellid):
-      '''Returns the dx of a given cell defined by its cellid
-      
-      :param cellid:        The cell's cellid
-      :returns:             The cell's size [dx, dy, dz]
-      '''
+      stack = True
+      if not hasattr(cellid,"__len__"):
+         cellid = np.atleast_1d(cellid)
+         stack = False
+
       cellid = np.array(cellid, dtype=np.int64)
 
       dxs = np.array([[self.__dx,self.__dy,self.__dz]])
 
       dxs = dxs.repeat(cellid.shape[0], axis=0)
 
-      amrs = np.array([self.get_amr_levels(cellid)]).transpose()
+      amrs = np.array([self.get_amr_level(cellid)]).transpose()
       amrs = amrs.repeat(3,axis=1)
 
-
-      return dxs/2**amrs
+      if stack:
+         return dxs/2**amrs
+      else:
+         return (dxs/2**amrs)[0]
 
    def get_cell_bbox(self, cellid):
       '''Returns the bounding box of a given cell defined by its cellid
@@ -1713,8 +1723,8 @@ class VlsvReader(object):
          sz_amr = self.get_spatial_mesh_size()
          max_amr_level = int(np.log2(sz[0] / sz_amr[0]))
          self.__vg_cellids_on_fg = np.zeros(sz, dtype=np.int64) + 1000000000 # big number to catch errors in the latter code, 0 is not good for that
-         amr_levels = self.get_amr_levels(vg_cellids)
-         cell_indices = np.array(self.get_cells_indices(vg_cellids,amr_levels),dtype=np.int64)
+         amr_levels = self.get_amr_level(vg_cellids)
+         cell_indices = np.array(self.get_cell_indices(vg_cellids,amr_levels),dtype=np.int64)
          refined_ids_start = np.array(cell_indices * 2**(max_amr_level-amr_levels[:,np.newaxis]), dtype=np.int64)
          refined_ids_end = np.array(refined_ids_start + 2**(max_amr_level-amr_levels[:,np.newaxis]), dtype=np.int64)
             
@@ -1724,8 +1734,6 @@ class VlsvReader(object):
                                     refined_ids_start[i,2]:refined_ids_end[i,2]] = i
 
       return self.__vg_cellids_on_fg
-
-
 
    def get_cell_fsgrid(self, cellid):
       '''Returns a slice tuple of fsgrid indices that are contained in the SpatialGrid
@@ -1804,52 +1812,8 @@ class VlsvReader(object):
 
           if AMR_count == refmax + 1:
               raise Exception('CellID does not exist in any AMR level')
-
-   def get_cell_coordinates(self, cellid):
-      ''' Returns a given cell's coordinates as a numpy array
-
-      :param cellid:            The cell's ID
-      :returns: a numpy array with the coordinates
-
-      .. seealso:: :func:`get_cellid`
-
-      .. note:: The cell ids go from 1 .. max not from 0
-      '''
-      # Get cell lengths:
-      xcells = self.__xcells
-      ycells = self.__ycells
-      zcells = self.__zcells
-      cellid = (int)(cellid - 1)
-      # Handle AMR
-      cellscount = self.__xcells*self.__ycells*self.__zcells
-      reflevel=0
-      subtraction = (int)(cellscount * (2**reflevel)**3)
-      while (cellid >= subtraction):
-         cellid -= subtraction
-         reflevel += 1
-         subtraction = (int)(cellscount * (2**reflevel)**3)
-         xcells *= 2
-         ycells *= 2
-         zcells *= 2
-      # Get cell indices:
-      cellindices = np.zeros(3)
-      cellindices[0] = (int)(cellid)%(int)(xcells)
-      cellindices[1] = ((int)(cellid)//(int)(xcells))%(int)(ycells)
-      cellindices[2] = (int)(cellid)//(int)(xcells*ycells)
-      # cellindices[0] = (int)(cellid)%(int)(self.__xcells)
-      # cellindices[1] = ((int)(cellid)//(int)(self.__xcells))%(int)(self.__ycells)
-      # cellindices[2] = (int)(cellid)//(int)(self.__xcells*self.__ycells)
    
-      # Get cell coordinates:
-      cell_lengths = np.array([(self.__xmax - self.__xmin)/(float)(xcells), (self.__ymax - self.__ymin)/(float)(ycells), (self.__zmax - self.__zmin)/(float)(zcells)])
-      cellcoordinates = np.zeros(3)
-      cellcoordinates[0] = self.__xmin + (cellindices[0] + 0.5) * cell_lengths[0]
-      cellcoordinates[1] = self.__ymin + (cellindices[1] + 0.5) * cell_lengths[1]
-      cellcoordinates[2] = self.__zmin + (cellindices[2] + 0.5) * cell_lengths[2]
-      # Return the coordinates:
-      return np.array(cellcoordinates)
-   
-   def get_cells_coordinates(self, cellids):
+   def get_cell_coordinates(self, cellids):
       ''' Returns a given cell's coordinates as a numpy array
 
       :param cellids:            The array of cell IDs
@@ -1859,6 +1823,12 @@ class VlsvReader(object):
 
       .. note:: The cell ids go from 1 .. max not from 0
       '''
+
+      stack = True
+      if not hasattr(cellids,"__len__"):
+         cellids = np.atleast_1d(cellids)
+         stack = False
+
       # Get cell lengths:
       xcells = np.zeros((self.get_max_refinement_level()+1), dtype=np.int64)
       ycells = np.zeros((self.get_max_refinement_level()+1), dtype=np.int64)
@@ -1868,29 +1838,9 @@ class VlsvReader(object):
          ycells[r] = self.__ycells*2**(r)
          zcells[r] = self.__zcells*2**(r)
 
-      # Handle AMR
-      cellid = np.array(cellids - 1, dtype=np.int64)
-      reflevels = np.zeros(np.array(cellid).shape, dtype=np.int64)
-      sub = np.ones(np.array(cellid).shape, dtype=np.int64)*(self.__xcells*self.__ycells*self.__zcells)
-      iters = 0
-      while np.any(cellid >= sub):
-         mask = cellid >= sub
-         np.subtract(cellid, sub, out = cellid, where = mask)
+      reflevels = self.get_amr_level(cellids)
+      cellindices = self.get_cell_indices(cellids)
 
-         np.add(reflevels, 1, out = reflevels, where = mask)
-         sub = (self.__xcells*self.__ycells*self.__zcells)*(2**(reflevels))**3
-         
-         iters = iters+1
-         if(iters > self.get_max_refinement_level()+1):
-            print("Can't have that large refinements. Something broke.")
-            break
-
-      # Get cell indices:
-      cellindices = np.zeros((len(cellids),3))
-      cellindices[:,0] = cellid%xcells[reflevels]
-      cellindices[:,1] = (cellid//xcells[reflevels])%ycells[reflevels]
-      cellindices[:,2] = cellid//(xcells[reflevels]*ycells[reflevels])
-   
       # Get cell coordinates:
       cell_lengths = np.array([(self.__xmax - self.__xmin)/(xcells[reflevels]),
                                (self.__ymax - self.__ymin)/(ycells[reflevels]),
@@ -1898,35 +1848,38 @@ class VlsvReader(object):
       mins = np.array([self.__xmin,self.__ymin,self.__zmin])
       cellcoordinates = mins + (cellindices + 0.5)*cell_lengths
       # Return the coordinates:
-      return np.array(cellcoordinates)
+      if stack:
+         return np.array(cellcoordinates)
+      else:
+         return np.array(cellcoordinates)[0]
 
-   def get_cell_indices(self, cellid, reflevel):
-      ''' Returns a given cell's indices as a numpy array
+   # def get_cell_indices(self, cellid, reflevel):
+   #    ''' Returns a given cell's indices as a numpy array
 
-      :param cellid:            The cell's ID
-      :param reflevel:          The cell's refinement level in the AMR
-      :returns: a numpy array with the coordinates
+   #    :param cellid:            The cell's ID
+   #    :param reflevel:          The cell's refinement level in the AMR
+   #    :returns: a numpy array with the coordinates
 
-      .. seealso:: :func:`get_cellid`
+   #    .. seealso:: :func:`get_cellid`
 
-      .. note:: The cell ids go from 1 .. max not from 0
-      '''
-      # Calculating the index of the first cell at this reflevel
-      index_at_reflevel = 0
-      for i in range(0,reflevel):
-         index_at_reflevel += 2**(3*i) * self.__xcells * self.__ycells * self.__zcells
+   #    .. note:: The cell ids go from 1 .. max not from 0
+   #    '''
+   #    # Calculating the index of the first cell at this reflevel
+   #    index_at_reflevel = 0
+   #    for i in range(0,reflevel):
+   #       index_at_reflevel += 2**(3*i) * self.__xcells * self.__ycells * self.__zcells
 
-      # Get cell indices:
-      cellid = (int)(cellid - 1 - index_at_reflevel)
-      cellindices = np.zeros(3)
-      cellindices[0] = (int)(cellid)%(int)(2**reflevel*self.__xcells)
-      cellindices[1] = ((int)(cellid)//(int)(2**reflevel*self.__xcells))%(int)(2**reflevel*self.__ycells)
-      cellindices[2] = (int)(cellid)//(int)(4**reflevel*self.__xcells*self.__ycells)
+   #    # Get cell indices:
+   #    cellid = (int)(cellid - 1 - index_at_reflevel)
+   #    cellindices = np.zeros(3)
+   #    cellindices[0] = (int)(cellid)%(int)(2**reflevel*self.__xcells)
+   #    cellindices[1] = ((int)(cellid)//(int)(2**reflevel*self.__xcells))%(int)(2**reflevel*self.__ycells)
+   #    cellindices[2] = (int)(cellid)//(int)(4**reflevel*self.__xcells*self.__ycells)
 
-      # Return the indices:
-      return np.array(cellindices)
+   #    # Return the indices:
+   #    return np.array(cellindices)
 
-   def get_cells_indices(self, cellid, reflevel):
+   def get_cell_indices(self, cellids, reflevels=None):
       ''' Returns a given cell's indices as a numpy array
 
       :param cellid:            The cell's ID, numpy array
@@ -1937,6 +1890,17 @@ class VlsvReader(object):
 
       .. note:: The cell ids go from 1 .. max not from 0
       '''
+
+      stack = True
+      if not hasattr(cellids,"__len__"):
+         cellids = np.atleast_1d(cellids)
+         stack = False
+
+      if reflevels is None:
+         reflevels = self.get_amr_level(cellids)
+      else:
+         reflevels = np.atleast_1d(reflevels)
+      
       # Calculating the index of the first cell at this reflevel
       index_at_reflevel = np.zeros(self.get_max_refinement_level()+1, dtype=np.int64)
       isum = 0
@@ -1946,14 +1910,17 @@ class VlsvReader(object):
 
 
       # Get cell indices:
-      cellid = np.array(cellid - 1 - index_at_reflevel[reflevel], dtype=np.int64).copy()
-      cellindices = np.zeros((len(cellid),3))
-      cellindices[:,0] = (cellid)%(np.power(2,reflevel)*self.__xcells)
-      cellindices[:,1] = ((cellid)//(np.power(2,reflevel)*self.__xcells))%(np.power(2,reflevel)*self.__ycells)
-      cellindices[:,2] = (cellid)//(np.power(4,reflevel)*self.__xcells*self.__ycells)
+      cellids = np.array(cellids - 1 - index_at_reflevel[reflevels], dtype=np.int64).copy()
+      cellindices = np.zeros((len(cellids),3))
+      cellindices[:,0] = (cellids)%(np.power(2,reflevels)*self.__xcells)
+      cellindices[:,1] = ((cellids)//(np.power(2,reflevels)*self.__xcells))%(np.power(2,reflevels)*self.__ycells)
+      cellindices[:,2] = (cellids)//(np.power(4,reflevels)*self.__xcells*self.__ycells)
 
       # Return the indices:
-      return np.array(cellindices)
+      if stack:
+         return np.array(cellindices)
+      else:
+         return np.array(cellindices)[0]
 
    def get_cell_neighbor(self, cellid, offset, periodic):
       ''' Returns a given cells neighbor at offset (in indices)

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1644,7 +1644,6 @@ class VlsvReader(object):
       '''Returns a subarray of the fsgrid array, corresponding to the (low, up) bounding box.
       '''
       lowi, upi = self.get_bbox_fsgrid_slicemap(low,up)
-      print('subarray:',lowi, upi)
       if array.ndim == 4:
          return array[lowi[0]:upi[0]+int(1), lowi[1]:upi[1]+int(1), lowi[2]:upi[2]+int(1), :]
       else:
@@ -1728,6 +1727,7 @@ class VlsvReader(object):
          refined_ids_start = np.array(cell_indices * 2**(max_amr_level-amr_levels[:,np.newaxis]), dtype=np.int64)
          refined_ids_end = np.array(refined_ids_start + 2**(max_amr_level-amr_levels[:,np.newaxis]), dtype=np.int64)
             
+         
          for i in range(vg_cellids.shape[0]):
             self.__vg_cellids_on_fg[refined_ids_start[i,0]:refined_ids_end[i,0],
                                     refined_ids_start[i,1]:refined_ids_end[i,1],

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1848,11 +1848,7 @@ class VlsvReader(object):
          zcells[r] = self.__zcells*2**(r)
 
       # Handle AMR
-      #reflevels=self.get_amr_levels(cellids)
-      # reflevels2 = np.array([self.get_amr_level(c) for c in cellids])
-      # print(np.all(reflevels == reflevels2)) # this is true.
       cellid = np.array(cellids - 1, dtype=np.int64)
-
       reflevels = np.zeros(np.array(cellid).shape, dtype=np.int64)
       sub = np.ones(np.array(cellid).shape, dtype=np.int64)*(self.__xcells*self.__ycells*self.__zcells)
       iters = 0
@@ -1873,20 +1869,13 @@ class VlsvReader(object):
       cellindices[:,0] = cellid%xcells[reflevels]
       cellindices[:,1] = (cellid//xcells[reflevels])%ycells[reflevels]
       cellindices[:,2] = cellid//(xcells[reflevels]*ycells[reflevels])
-      # cellindices[0] = (int)(cellid)%(int)(self.__xcells)
-      # cellindices[1] = ((int)(cellid)//(int)(self.__xcells))%(int)(self.__ycells)
-      # cellindices[2] = (int)(cellid)//(int)(self.__xcells*self.__ycells)
    
       # Get cell coordinates:
       cell_lengths = np.array([(self.__xmax - self.__xmin)/(xcells[reflevels]),
                                (self.__ymax - self.__ymin)/(ycells[reflevels]),
                                (self.__zmax - self.__zmin)/(zcells[reflevels])]).T
-      #cellcoordinates = np.zeros((len(cellids),3))
       mins = np.array([self.__xmin,self.__ymin,self.__zmin])
       cellcoordinates = mins + (cellindices + 0.5)*cell_lengths
-      # cellcoordinates[:,0] = self.__xmin + (cellindices[:,0] + 0.5) * cell_lengths[:,0]
-      # cellcoordinates[:,1] = self.__ymin + (cellindices[:,1] + 0.5) * cell_lengths[:,1]
-      # cellcoordinates[:,2] = self.__zmin + (cellindices[:,2] + 0.5) * cell_lengths[:,2]
       # Return the coordinates:
       return np.array(cellcoordinates)
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1341,7 +1341,6 @@ class VlsvReader(object):
          singletons = [i for i, sz in enumerate(fssize) if sz == 1]
          for dim in singletons:
             fgdata=np.expand_dims(fgdata, dim)
-      #print('read in fgdata with shape', fgdata.shape, name)
       celldata = np.zeros_like(fgdata)
       known_centerings = {"fg_b":"face", "fg_e":"edge"}
       if centering is None:
@@ -1576,7 +1575,6 @@ class VlsvReader(object):
       
       hdx = self.get_cell_dx(cellid)*0.5
       mid = self.get_cell_coordinates(cellid)
-      #print('halfdx:', hdx, 'mid:', mid, 'low:', mid-hdx, 'hi:', mid+hdx)
       return mid-hdx, mid+hdx
 
    def get_cell_fsgrid_slicemap(self, cellid):
@@ -1598,7 +1596,6 @@ class VlsvReader(object):
       covered by the SpatialGrid cellid.
       '''
       lowi, upi = self.get_cell_fsgrid_slicemap(cellid)
-      #print('subarray:',lowi, upi)
       if array.ndim == 4:
          return array[lowi[0]:upi[0]+1, lowi[1]:upi[1]+1, lowi[2]:upi[2]+1, :]
       else:
@@ -1666,12 +1663,9 @@ class VlsvReader(object):
       cellid. Mutator for array.
       '''
       lowi, upi = self.get_cell_fsgrid_slicemap(cellid)
-      #print(lowi,upi)
       value = self.read_variable(var, cellids=[cellid])
       if array.ndim == 4:
-         #print(value)
          array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1,:] = value
-         #print(array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1,:])
       else:
          array[lowi[0]:upi[0]+1,lowi[1]:upi[1]+1,lowi[2]:upi[2]+1] = value
       return

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1537,18 +1537,6 @@ class VlsvReader(object):
             
          self.__max_spatial_amr_level = AMR_count - 1
       return self.__max_spatial_amr_level
-      
-   # def get_amr_level(self,cellid):
-   #    '''Returns the AMR level of a given cell defined by its cellid
-      
-   #    :param cellid:        The cell's cellid
-   #    :returns:             The cell's refinement level in the AMR
-   #    '''
-   #    AMR_count = 0
-   #    while (cellid > 0):
-   #       cellid -= 2**(3*(AMR_count))*(self.__xcells*self.__ycells*self.__zcells)
-   #       AMR_count += 1
-   #    return AMR_count - 1 
 
    def get_amr_level(self,cellid):
       '''Returns the AMR level of a given cell defined by its cellid
@@ -1858,32 +1846,6 @@ class VlsvReader(object):
          return np.array(cellcoordinates)
       else:
          return np.array(cellcoordinates)[0]
-
-   # def get_cell_indices(self, cellid, reflevel):
-   #    ''' Returns a given cell's indices as a numpy array
-
-   #    :param cellid:            The cell's ID
-   #    :param reflevel:          The cell's refinement level in the AMR
-   #    :returns: a numpy array with the coordinates
-
-   #    .. seealso:: :func:`get_cellid`
-
-   #    .. note:: The cell ids go from 1 .. max not from 0
-   #    '''
-   #    # Calculating the index of the first cell at this reflevel
-   #    index_at_reflevel = 0
-   #    for i in range(0,reflevel):
-   #       index_at_reflevel += 2**(3*i) * self.__xcells * self.__ycells * self.__zcells
-
-   #    # Get cell indices:
-   #    cellid = (int)(cellid - 1 - index_at_reflevel)
-   #    cellindices = np.zeros(3)
-   #    cellindices[0] = (int)(cellid)%(int)(2**reflevel*self.__xcells)
-   #    cellindices[1] = ((int)(cellid)//(int)(2**reflevel*self.__xcells))%(int)(2**reflevel*self.__ycells)
-   #    cellindices[2] = (int)(cellid)//(int)(4**reflevel*self.__xcells*self.__ycells)
-
-   #    # Return the indices:
-   #    return np.array(cellindices)
 
    def get_cell_indices(self, cellids, reflevels=None):
       ''' Returns a given cell's indices as a numpy array

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -101,6 +101,8 @@ class VlsvWriter(object):
                   extra_attribs[i[0]] = i[1]
             data = vlsvReader.read( name=name, tag=tag, mesh=mesh )
             # Write the data:
+            #print("writing",name, tag)
+
             self.write( data=data, name=name, tag=tag, mesh=mesh, extra_attribs=extra_attribs )
 
 

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -282,10 +282,10 @@ class VlsvWriter(object):
          -data: The variable data (array)
          -name: Name of the data array
          -latex: LaTeX string representation of the variable name
-         -units: plaintext string represenation of the unit
-         -latexunits: LaTeX string represenation of the unit
+         -units: plaintext string representation of the unit
+         -latexunits: LaTeX string representation of the unit
       :param mesh: Mesh for the data array
-      :param unitConversion: string represenation of the unit conversion to get to SI
+      :param unitConversion: string representation of the unit conversion to get to SI
       :param extra_attribs: Dictionary with whatever xml attributes that should be defined in the array that aren't name, tag, or mesh,
         or contained in varinfo. Can be used to overwrite varinfo values besids name.
 

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -162,11 +162,11 @@ class VlsvWriter(object):
       for child in xml_root:
          if child.tag in tags:
             if 'name' in child.attrib:
-                name = child.attrib['name']
-                if not name in vars:
+               name = child.attrib['name']
+               if not name in vars:
                   continue
-                else:
-                   found_vars.append(name)
+               else:
+                  found_vars.append(name)
             else:
                 continue
             if 'mesh' in child.attrib:

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -163,7 +163,10 @@ class VlsvWriter(object):
             if 'name' in child.attrib:
                 name = child.attrib['name']
                 if not name in vars:
-                   continue
+                  continue
+                  #  varinfo = vlsvReader.read_variable_info(name)
+                  #  self.write_variable_info(varinfo, mesh, unitConversion, extra_attribs={}))
+                  #  continue
             else:
                 continue
             if 'mesh' in child.attrib:

--- a/pyVlsv/vlsvwriter.py
+++ b/pyVlsv/vlsvwriter.py
@@ -273,7 +273,6 @@ class VlsvWriter(object):
          return False
       
       if (extra_attribs != '') and (extra_attribs is not None):
-         print(extra_attribs)
          for i in extra_attribs.items():
             child.attrib[i[0]] = i[1]
 


### PR DESCRIPTION
Fast SpatialGrid coordinate extraction (plus AMR level and dx extraction), accessible also via `read_variable("vg_dxs")` and `read_variable("vg_coordinates")` - needed special handling though, since I want to use these in xo_tools datareducers.