### PR TITLE
Fixing np.int deprecation

### DIFF
--- a/pyPlots/plot_isosurface.py
+++ b/pyPlots/plot_isosurface.py
@@ -176,7 +176,7 @@ def plot_isosurface(filename=None,
             print("Unknown time format encountered")
             plot_title = ''
         else:
-            #plot_title = "t="+str(np.int(timeval))+' s'
+            #plot_title = "t="+str(int(timeval))+' s'
             plot_title = "t="+'{:4.2f}'.format(timeval)+' s'
     else:
         plot_title = title
@@ -758,7 +758,7 @@ def plot_isosurface(filename=None,
             try:
                 plt.savefig(savefigname,dpi=300, bbox_inches=bbox_inches, pad_inches=savefig_pad)
             except:
-                plot_title = "t="+str(np.int(timeval))+' s   '
+                plot_title = "t="+str(int(timeval))+' s   '
                 ax1.set_title(plot_title,fontsize=fontsize2,fontweight='bold')                
                 try:
                     plt.savefig(savefigname,dpi=300, bbox_inches=bbox_inches, pad_inches=savefig_pad)

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -611,7 +611,7 @@ def plot_vdf(filename=None,
             stepstr = '_'+str(step).rjust(7,'0')
         else:
             if timeval != None:
-                stepstr = '_t'+str(np.int(timeval))
+                stepstr = '_t'+str(int(timeval))
             else:
                 stepstr = ''
 

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -402,7 +402,7 @@ def plot_vdf_profiles(filename=None,
             stepstr = '_'+str(step).rjust(7,'0')
         else:
             if timeval != None:
-                stepstr = '_t'+str(np.int(timeval))
+                stepstr = '_t'+str(int(timeval))
             else:
                 stepstr = ''
 


### PR DESCRIPTION
Fixed few instances of `np.int` to plain `int` (step/time numbers)
```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```