### PR TITLE
RBFInterpolator guarding

### DIFF
--- a/pyCalculations/interpolator_amr.py
+++ b/pyCalculations/interpolator_amr.py
@@ -1,13 +1,17 @@
 from scipy.spatial import Delaunay
 import numpy as np
 from scipy.interpolate import LinearNDInterpolator
+
+import warnings
+
 try:
    from scipy.interpolate import RBFInterpolator
 except:
-   def RBFInterpolator(*args, **kwargs):
-      print("RBFInterpolator could not be imported. SciPy >= 1.7 is required for this class.")
+   def RBFInterpolator(pts, vals, **kwargs):
+      warnings.warn("RBFInterpolator could not be imported. SciPy >= 1.7 is required for this class. Falling back to Hexahedral trilinear itnerpolator.")
+      return HexahedralTrilinearInterpolator(pts,vals,**kwargs)
+
       
-import warnings
 from variable import get_data
 
 

--- a/pyCalculations/interpolator_amr.py
+++ b/pyCalculations/interpolator_amr.py
@@ -4,15 +4,16 @@ from scipy.interpolate import LinearNDInterpolator
 
 import warnings
 
+importerror = None
+
 try:
    from scipy.interpolate import RBFInterpolator
-except:
-   def RBFInterpolator(pts, vals, **kwargs):
-      warnings.warn("RBFInterpolator could not be imported. SciPy >= 1.7 is required for this class. Falling back to Hexahedral trilinear itnerpolator.")
-      return HexahedralTrilinearInterpolator(pts,vals,**kwargs)
-
-      
-from variable import get_data
+except Exception as e:
+   importerror = e
+   class RBFInterpolator(object):
+      def __init__(self, pts, vals, **kwargs):
+         raise importerror #Exception("Module load error")
+   
 
 
 # With values fi at hexahedral vertices and trilinear basis coordinates ksi,
@@ -161,7 +162,7 @@ class AMRInterpolator(object):
    def get_interpolator(self, name, operator, coords, 
                         method="RBF", 
                         methodargs={
-                           "RBF":{"neighbors":64},
+                           "RBF":{"neighbors":64}, # Harrison-Stetson number of neighbors
                            "Delaunay":{"qhull_options":"QJ"}
                            }):
       methodargs["Trilinear"] = {"reader":self.__reader, "var" : name, "op":operator}
@@ -172,7 +173,11 @@ class AMRInterpolator(object):
          self.__Delaunay = Delaunay(self.reader.get_cell_coordinates(self.__cellids),**methodargs[method])
          return LinearNDInterpolator(self.__Delaunay, vals)
       elif method == "RBF":
-         return RBFInterpolator(pts, vals, **methodargs[method]) # Harrison-Stetson number of neighbors
+         try:
+            return RBFInterpolator(pts, vals, **methodargs[method])
+         except Exception as e:
+            warnings.warn("RBFInterpolator could not be imported. SciPy >= 1.7 is required for this class. Falling back to Hexahedral trilinear interpolator. Error given was " + str(e))
+            return HexahedralTrilinearInterpolator(pts, vals, **methodargs["Trilinear"])
       elif method == "Trilinear":
          return HexahedralTrilinearInterpolator(pts, vals, **methodargs[method])
 

--- a/pyCalculations/interpolator_amr.py
+++ b/pyCalculations/interpolator_amr.py
@@ -1,6 +1,12 @@
 from scipy.spatial import Delaunay
 import numpy as np
-from scipy.interpolate import LinearNDInterpolator, RBFInterpolator
+from scipy.interpolate import LinearNDInterpolator
+try:
+   from scipy.interpolate import RBFInterpolator
+except:
+   def RBFInterpolator(*args, **kwargs):
+      print("RBFInterpolator could not be imported. SciPy >= 1.7 is required for this class.")
+      
 import warnings
 from variable import get_data
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -39,8 +39,6 @@ from collections import OrderedDict
 from vlsvwriter import VlsvWriter
 from variable import get_data
 import warnings
-from scipy.interpolate import LinearNDInterpolator
-from scipy.spatial import Delaunay
 import time
 from interpolator_amr import AMRInterpolator
 


### PR DESCRIPTION
RBF interpolator not available on old SciPy versions, this guards against that with a fallback and a warning message. Also a bit of cleanup.