### PR TITLE
Suppress confusing printouts

### DIFF
--- a/pyCalculations/variable.py
+++ b/pyCalculations/variable.py
@@ -168,7 +168,6 @@ class VariableInfo:
          try:
             udict = self.scaleDict[dictKey]
          except:
-            print('No entry in specialist dict for unit "' + self.units+ '"')
             if vscale is None:
                return 1.0, self.units, self.latexunits
             else:
@@ -177,7 +176,6 @@ class VariableInfo:
             try:
                unitScale = udict['defaultScale']
             except:
-               print('No vscale or defaultScale in specialist dict for unit "' + self.units +'"')
                return 1.0, self.units, self.latexunits
          elif np.isclose(vscale, 1.0):
                return 1.0, self.units, self.latexunits
@@ -192,12 +190,12 @@ class VariableInfo:
             unitScale = [scale for scale in udict.keys() if isinstance(scale, Number) and np.isclose(scale,unitScale)][0]
             scaledUnits = udict[unitScale]['scaledUnits']
          except KeyError:
-            print('Missing scaledUnits in specialist dict for' + self.units + ' for unitScale='+str(unitScale))
+            # print('Missing scaledUnits in specialist dict for' + self.units + ' for unitScale='+str(unitScale))
             return 1.0, self.units, self.latexunits
          try:
             scaledLatexUnits = udict[unitScale]['scaledLatexUnit']
          except:
-            print('Missing scaledLatexUnits in specialist dict for ' + self.units+ ' for unitScale='+str(unitScale))
+            # print('Missing scaledLatexUnits in specialist dict for ' + self.units+ ' for unitScale='+str(unitScale))
             return 1.0, self.units, self.latexunits
       else:
           if vscale is None or np.isclose(vscale, 1.0):


### PR DESCRIPTION
Suppress the warning printouts. The commented-out ones are not exactly cut-and-dry, since they could indicate missing entries in an existing custom dict, but there was something about the behavior with the default case that had me scratching my head. At least this will be less confusing for now.