### PR TITLE
Fix plot vdf centering

### DIFF
--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -271,14 +271,15 @@ def vSpaceReducer(vlsvReader, cid, slicetype, normvect, VXBins, VYBins, pop="pro
     print("Found "+str(len(V))+" v-space cells")
 
     # center on highest f-value
-    if center == "peak":
+    if str(center) == "peak":
         peakindex = np.argmax(f)
         Vpeak = V[peakindex,:]
         V = V - Vpeak
-        print(peakindex)
+        #print(peakindex)
         print("Transforming to frame of peak f-value, travelling at speed "+str(Vpeak))
     elif not center is None:
-        if len(center)==3: # assumes it's a vector
+        # assumes it's a vector, either provided or extracted from bulk velocity
+        if len(center)==3:
             print("Transforming to frame travelling at speed "+str(center))
             V = V - center
         else:
@@ -973,8 +974,9 @@ def plot_vdf(filename=None,
             normvectX = normvectX/np.linalg.norm(normvectX)
 
 
-        if cbulk is not None or center=='bulk':
-            center=None # Finds the bulk velocity and places it in the center vector
+        if (cbulk is not None) or (str(center)=='bulk'):
+            center = None # Fallthrough handling
+            # Finds the bulk velocity and places it in the center vector
             print("Transforming to plasma frame")
             if type(cbulk) is str:
                 if vlsvReader.check_variable(cbulk):
@@ -982,7 +984,7 @@ def plot_vdf(filename=None,
                     print("Found bulk frame from variable "+cbulk)
             else:
                 center = Vbulk
-
+        # Note: center can still be equal to vector, or to the string "peak" and be valid
 
         # Geometric magic to stretch the grid to assure that each cell has some velocity grid points inside it.
         # Might still be incorrect, erring on the side of caution.

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -427,7 +427,7 @@ def plot_vdf(filename=None,
              bpara=None, bpara1=None, bperp=None,
              coordswap=None,
              bvector=None,bvectorscale=0.2,
-             cbulk=None, center=None, wflux=None, setThreshold=None,
+             cbulk=None, cpeak=None,center=None, wflux=None, setThreshold=None,
              noborder=None, scale=1.0, scale_text=8.0, scale_title=10.0,scale_cb=5.0,scale_label=12.0,
              biglabel=None, biglabloc=None,
              noxlabels=None, noylabels=None,
@@ -486,6 +486,8 @@ def plot_vdf(filename=None,
 
     :kword cbulk:       Center plot on position of total bulk velocity (or if not available,
                         bulk velocity for this population)
+    :kword cpeak:       Center plot on velocity associated with highest (peak) phase-space density for
+                        this population)
     :kword center:      Center plot on provided 3-element velocity vector position (in m/s)
                         If set instead to "bulk" will center on bulk velocity
                         If set instead to "peak" will center on velocity with highest phase-space density
@@ -973,7 +975,8 @@ def plot_vdf(filename=None,
             normvectX = np.array(normvectX)
             normvectX = normvectX/np.linalg.norm(normvectX)
 
-
+        if (cpeak is not None):
+            center='peak'
         if (cbulk is not None) or (str(center)=='bulk'):
             center = None # Fallthrough handling
             # Finds the bulk velocity and places it in the center vector


### PR DESCRIPTION
Previously, the checks for `cbulk is not None` or the `center` keyword being set to "bulk" or "centre" were sloppy and sometimes warned or errored. Still not pythonesque with try-catches but might work better now?