### PR TITLE
added nearest_vdf keyword to vlsvReader's get_cellid()

### DIFF
--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -743,7 +743,7 @@ def plot_vdf(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop=pop)   # deprecated getNearestCellWithVspace(). needs testing
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(np.array([xReq[ii],yReq[ii],zReq[ii]]), pop=pop)   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -743,7 +743,7 @@ def plot_vdf(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop=pop)   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -45,22 +45,6 @@ from rotation import rotateVectorToVector,rotateVectorToVector_X
 # Retained for reference, if the large differences in VDF values come back to haunt
 logspaceResample = False
 
-# find nearest spatial cell with vspace to cid
-def getNearestCellWithVspace(vlsvReader,cid):
-    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
-    return vlsvReader.get_cellid_with_vdf(cell_coordinates)
-    ''' v deprecated v
-    cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
-    if len(cell_candidates)==0:
-        print("Error: No velocity distributions found!")
-        sys.exit()
-    cell_candidate_coordinates = [vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
-    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
-    norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
-    norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
-    return cell_candidates[i]
-    '''
-
 # Verify that given cell has a saved vspace
 def verifyCellWithVspace(vlsvReader,cid):
     cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS').tolist()
@@ -759,7 +743,7 @@ def plot_vdf(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = getNearestCellWithVspace(vlsvReader,cidRequest)
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -47,6 +47,9 @@ logspaceResample = False
 
 # find nearest spatial cell with vspace to cid
 def getNearestCellWithVspace(vlsvReader,cid):
+    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
+    return vlsvReader.get_cellid_with_vdf(cell_coordinates)
+    ''' v deprecated v
     cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
     if len(cell_candidates)==0:
         print("Error: No velocity distributions found!")
@@ -56,6 +59,7 @@ def getNearestCellWithVspace(vlsvReader,cid):
     norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
     norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
     return cell_candidates[i]
+    '''
 
 # Verify that given cell has a saved vspace
 def verifyCellWithVspace(vlsvReader,cid):

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -42,6 +42,9 @@ from rotation import rotateVectorToVector,rotateVectorToVector_X
 
 # find nearest spatial cell with vspace to cid
 def getNearestCellWithVspace(vlsvReader,cid):
+    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
+    return vlsvReader.get_cellid_with_vdf(cell_coordinates)
+    ''' v deprecated v
     cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
     if len(cell_candidates)==0:
         print("Error: No velocity distributions found!")
@@ -51,6 +54,7 @@ def getNearestCellWithVspace(vlsvReader,cid):
     norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
     norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
     return cell_candidates[i]
+    '''
 
 # Verify that given cell has a saved vspace
 def verifyCellWithVspace(vlsvReader,cid):

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -523,7 +523,7 @@ def plot_vdf_profiles(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop = pop)   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -523,7 +523,7 @@ def plot_vdf_profiles(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop = pop)   # deprecated getNearestCellWithVspace(). needs testing
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(np.array([xReq[ii],yReq[ii],zReq[ii]]), pop = pop)   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -40,22 +40,6 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from rotation import rotateVectorToVector,rotateVectorToVector_X
 
-# find nearest spatial cell with vspace to cid
-def getNearestCellWithVspace(vlsvReader,cid):
-    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
-    return vlsvReader.get_cellid_with_vdf(cell_coordinates)
-    ''' v deprecated v
-    cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
-    if len(cell_candidates)==0:
-        print("Error: No velocity distributions found!")
-        sys.exit()
-    cell_candidate_coordinates = [vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
-    cell_coordinates = vlsvReader.get_cell_coordinates(cid)
-    norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
-    norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
-    return cell_candidates[i]
-    '''
-
 # Verify that given cell has a saved vspace
 def verifyCellWithVspace(vlsvReader,cid):
     cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS').tolist()
@@ -539,7 +523,7 @@ def plot_vdf_profiles(filename=None,
             cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
             cidNearestVspace = -1
             if cidRequest > 0:
-                cidNearestVspace = getNearestCellWithVspace(vlsvReader,cidRequest)
+                cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
             else:
                 print('ERROR: cell not found')
                 sys.exit()

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -2099,6 +2099,8 @@ class VlsvReader(object):
       else:
          return cellids[0]
 
+   from myutils import timer
+   @timer
    def get_cellid_with_vdf(self, coords, pop = 'proton'):
       ''' Returns the cell ids nearest to test points, that contain VDFs
 
@@ -2138,18 +2140,20 @@ class VlsvReader(object):
       
       # Direct search: calculate distances for each pair points (test <--> vdf cells)
       # Only calculate nearest distance if there is no VDF already in the cell (using flag_empty_in) 
+      '''
       try:
          # Vectorized approach: 
          dist2 = np.nansum((coords_in[flag_empty_in, None, :] - coords_w_vdf[None, :, :])**2, axis = -1)   # distance^2, shape [N_empty_in, N_w_vdf]
          output[flag_empty_in] = cid_w_vdf[np.argmin(dist2, axis = 1)]
       except MemoryError:
-         # Loop approach:
-         print('Not enough memory to broadcast arrays! Using a loop instead...')
-         ind_emptycell = np.arange(len(flag_empty_in))[flag_empty_in]
-         for ind in ind_emptycell:
-            this_coord = coords_in[ind, :]
-            dist2 = np.nansum((coords_w_vdf - this_coord)**2, axis = -1)
-            output[ind] = cid_w_vdf[np.argmin(dist2)]
+      '''
+      # Loop approach:
+      print('Not enough memory to broadcast arrays! Using a loop instead...')
+      ind_emptycell = np.arange(len(flag_empty_in))[flag_empty_in]
+      for ind in ind_emptycell:
+         this_coord = coords_in[ind, :]
+         dist2 = np.nansum((coords_w_vdf - this_coord)**2, axis = -1)
+         output[ind] = cid_w_vdf[np.argmin(dist2)]
 
       # return cells that minimize the distance to the test points
       if stack:

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -2099,8 +2099,6 @@ class VlsvReader(object):
       else:
          return cellids[0]
 
-   from myutils import timer
-   @timer
    def get_cellid_with_vdf(self, coords, pop = 'proton'):
       ''' Returns the cell ids nearest to test points, that contain VDFs
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -2130,16 +2130,17 @@ class VlsvReader(object):
       flag_empty_in = np.array( [cid not in self.__order_for_cellid_blocks[pop] for cid in output] )
       N_empty_in = sum(flag_empty_in)
 
-      if N_empty_in == 0:
-         return output  # every element of coords_in already within a vdf-containing cell
+      if N_empty_in == 0:   # every element of coords_in already within a vdf-containing cell
+         if stack:
+            return output
+         else:
+            return output[0]
       
       # Direct search: calculate distances for each pair points (test <--> vdf cells)
       # Only calculate nearest distance if there is no VDF already in the cell (using flag_empty_in) 
       try:
          # Vectorized approach: 
-         coords_in_rpt = coords_in[flag_empty_in, None, :]
-         coords_w_vdf_rpt = coords_w_vdf[None, :, :]
-         dist2 = np.nansum((coords_in_rpt - coords_w_vdf_rpt)**2, axis = -1)   # distance^2, shape [N_empty_in, N_w_vdf]
+         dist2 = np.nansum((coords_in[flag_empty_in, None, :] - coords_w_vdf[None, :, :])**2, axis = -1)   # distance^2, shape [N_empty_in, N_w_vdf]
          output[flag_empty_in] = cid_w_vdf[np.argmin(dist2, axis = 1)]
       except MemoryError:
          # Loop approach:

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -2115,7 +2115,9 @@ class VlsvReader(object):
          coords_in = np.atleast_2d(coords_in)
          stack = False
 
-      cid_w_vdf = self.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
+      if not pop in self.__cells_with_blocks:
+         self.__set_cell_offset_and_blocks_nodict(pop)
+      cid_w_vdf = self.__cells_with_blocks[pop]
       coords_w_vdf = self.get_cell_coordinates(cid_w_vdf)
       N_in = coords_in.shape[0]; N_w_vdf = len(cid_w_vdf)
 
@@ -2125,8 +2127,6 @@ class VlsvReader(object):
 
       # Boolean array flag_empty_in indicates if queried points (coords_in) don't already lie within vdf-containing cells, 
       output = self.get_cellid(coords_in)
-      if not pop in self.__cells_with_blocks:
-         self.__set_cell_offset_and_blocks_nodict(pop)
       flag_empty_in = np.array( [cid not in self.__order_for_cellid_blocks[pop] for cid in output] )
       N_empty_in = sum(flag_empty_in)
 

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -2137,8 +2137,8 @@ class VlsvReader(object):
       # Only calculate nearest distance if there is no VDF already in the cell (using flag_empty_in) 
       try:
          # Vectorized approach: 
-         coords_in_rpt = np.repeat(coords_in[flag_empty_in, None, :], N_w_vdf, axis=1)
-         coords_w_vdf_rpt = np.repeat(coords_w_vdf[None, :, :], N_empty_in, axis=0)
+         coords_in_rpt = coords_in[flag_empty_in, None, :]
+         coords_w_vdf_rpt = coords_w_vdf[None, :, :]
          dist2 = np.nansum((coords_in_rpt - coords_w_vdf_rpt)**2, axis = -1)   # distance^2, shape [N_empty_in, N_w_vdf]
          output[flag_empty_in] = cid_w_vdf[np.argmin(dist2, axis = 1)]
       except MemoryError:

--- a/scripts/create_time_energy_spectrogram.py
+++ b/scripts/create_time_energy_spectrogram.py
@@ -165,7 +165,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop='proton')   # deprecated getNearestCellWithVspace(). needs testing
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(np.array([xReq[ii],yReq[ii],zReq[ii]]), pop='proton')   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()

--- a/scripts/create_time_energy_spectrogram.py
+++ b/scripts/create_time_energy_spectrogram.py
@@ -147,19 +147,6 @@ print('VLSV files found: ' + str(Ntimes))
 #xReq = 1*Re; yReq = 0; zReq = -13*Re;
 #xReq = 1*Re; yReq = 0; zReq = -7*Re;
 
-# find nearest spatial cell with vspace to cid
-def getNearestCellWithVspace(vlsvReader,cid):
- cell_coordinates = vlsvReader.get_cell_coordinates(cid)
- return vlsvReader.get_cellid_with_vdf(cell_coordinates)
- ''' v deprecated v 
- cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
- cell_candidate_coordinates = [vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
- cell_coordinates = vlsvReader.get_cell_coordinates(cid)
- norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
- norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
- return cell_candidates[i]
- '''
-
 # find cell ids with vspace to be analyzed if not given
 vlsvReader = pt.vlsvfile.VlsvReader(vlsvFiles[0])
 cidsTemp = []
@@ -178,7 +165,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = getNearestCellWithVspace(vlsvReader,cidRequest)
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()

--- a/scripts/create_time_energy_spectrogram.py
+++ b/scripts/create_time_energy_spectrogram.py
@@ -149,12 +149,16 @@ print('VLSV files found: ' + str(Ntimes))
 
 # find nearest spatial cell with vspace to cid
 def getNearestCellWithVspace(vlsvReader,cid):
+ cell_coordinates = vlsvReader.get_cell_coordinates(cid)
+ return vlsvReader.get_cellid_with_vdf(cell_coordinates)
+ ''' v deprecated v 
  cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
  cell_candidate_coordinates = [vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
  cell_coordinates = vlsvReader.get_cell_coordinates(cid)
  norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
  norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
  return cell_candidates[i]
+ '''
 
 # find cell ids with vspace to be analyzed if not given
 vlsvReader = pt.vlsvfile.VlsvReader(vlsvFiles[0])

--- a/scripts/create_time_energy_spectrogram.py
+++ b/scripts/create_time_energy_spectrogram.py
@@ -165,7 +165,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop='proton')   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()

--- a/trash_can/plot_veldist.py
+++ b/trash_can/plot_veldist.py
@@ -159,7 +159,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop = 'proton')   # deprecated getNearestCellWithVspace(). needs testing
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(np.array([xReq[ii],yReq[ii],zReq[ii]]), pop = 'proton')   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()

--- a/trash_can/plot_veldist.py
+++ b/trash_can/plot_veldist.py
@@ -141,15 +141,6 @@ if 'vlsvFiles' not in locals():
 Ntimes = len(vlsvFiles)
 print('VLSV files found: ' + str(Ntimes))
 
-# find nearest spatial cell with vspace to cid
-def getNearestCellWithVspace(vlsvReader,cid):
- cell_candidates = vlsvReader.read(mesh='SpatialGrid',tag='CELLSWITHBLOCKS')
- cell_candidate_coordinates = [vlsvReader.get_cell_coordinates(cell_candidate) for cell_candidate in cell_candidates]
- cell_coordinates = vlsvReader.get_cell_coordinates(cid)
- norms = np.sum((cell_candidate_coordinates - cell_coordinates)**2, axis=-1)**(1./2)
- norm, i = min((norm, idx) for (idx, norm) in enumerate(norms))
- return cell_candidates[i]
-
 # find cell ids with vspace to be analyzed if not given
 vlsvReader = pt.vlsvfile.VlsvReader(vlsvFiles[0])
 cidsTemp = []
@@ -168,7 +159,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = getNearestCellWithVspace(vlsvReader,cidRequest)
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()

--- a/trash_can/plot_veldist.py
+++ b/trash_can/plot_veldist.py
@@ -159,7 +159,7 @@ if 'cids' not in locals():
   cidRequest = (np.int64)(vlsvReader.get_cellid(np.array([xReq[ii],yReq[ii],zReq[ii]])))
   cidNearestVspace = -1
   if cidRequest > 0:
-   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest))   # deprecated getNearestCellWithVspace(). needs testing
+   cidNearestVspace = vlsvReader.get_cellid_with_vdf(vlsvReader.get_cell_coordinates(cidRequest), pop = 'proton')   # deprecated getNearestCellWithVspace(). needs testing
   else:
    print('ERROR: cell not found')
    quit()


### PR DESCRIPTION
If nearest_vdf==True, get_cellid() will return the cellid of the nearest cell that contains vdf data.
Tested with visit to check if function gets the right cellids input and output.
Data types (scalar vs. array) are handled, same behavior regardless of whether nearest_vdf==True