### PR TITLE
Enable deprecationwarnings

### DIFF
--- a/pytools.py
+++ b/pytools.py
@@ -23,6 +23,8 @@
 
 import filemanagement
 import socket, re, os, tempfile, atexit, shutil
+import warnings
+warnings.filterwarnings("once", category=DeprecationWarning)
 
 # Input current folder's path
 filemanagement.sys.path.insert(0, filemanagement.os.path.dirname(filemanagement.os.path.abspath(__file__)))


### PR DESCRIPTION
Quick addition to enable DeprecationWarnings, since https://peps.python.org/pep-0565/ disables them from imported modules. This way we can stay ahead of the curve a bit better...

This also immediately shows that our current method of handling deprecated APIs is going to be deprecated:

```
/home/mjalho/proj/analysator/pyPlots/plot_colormap.py:41: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import LooseVersion, StrictVersion
```