### PR TITLE
Close figures after save

### DIFF
--- a/pyPlots/plot_colormap.py
+++ b/pyPlots/plot_colormap.py
@@ -1319,6 +1319,7 @@ def plot_colormap(filename=None,
         except:
             print("Error with attempting to save figure.")
         print(outputfile+"\n")
+        plt.close()
     elif not axes:
         # Draw on-screen
         plt.draw()

--- a/pyPlots/plot_colormap3dslice.py
+++ b/pyPlots/plot_colormap3dslice.py
@@ -1530,6 +1530,7 @@ def plot_colormap3dslice(filename=None,
         except:
             print("Error with attempting to save figure.")
         print(outputfile+"\n")
+        plt.close()
     elif not axes:
         # Draw on-screen
         plt.draw()

--- a/pyPlots/plot_ionosphere.py
+++ b/pyPlots/plot_ionosphere.py
@@ -607,6 +607,7 @@ def plot_ionosphere(filename=None,
         except:
             print("Error attempting to save figure: ", sys.exc_info())
         print('...Done!') 
+        plt.close()
     elif draw is not None and axes is None:
         # Draw on-screen
         plt.draw()

--- a/pyPlots/plot_threeslice.py
+++ b/pyPlots/plot_threeslice.py
@@ -1746,6 +1746,7 @@ def plot_threeslice(filename=None,
         except:
             print("Error with attempting to save figure.")
             print('...Done! Time since start = {:.2f} s'.format(time.time()-t0))
+        plt.close()
     else:
         # Draw on-screen
         plt.draw()

--- a/pyPlots/plot_vdf.py
+++ b/pyPlots/plot_vdf.py
@@ -1353,6 +1353,7 @@ def plot_vdf(filename=None,
             except:
                 print("Error with attempting to save figure due to matplotlib LaTeX integration.")
             print(savefigname+"\n")
+            plt.close()
         elif axes is None:
             # Draw on-screen
             plt.draw()

--- a/pyPlots/plot_vdf_profiles.py
+++ b/pyPlots/plot_vdf_profiles.py
@@ -942,6 +942,7 @@ def plot_vdf_profiles(filename=None,
             except:
                 print("Error with attempting to save figure due to matplotlib LaTeX integration.")
             print(savefigname+"\n")
+            plt.close()
         elif axes==None:
             # Draw on-screen
             plt.draw()


### PR DESCRIPTION
Added plt.close() to the plot functions where the figure is attempted to be saved, and not when draw=1 or axes!=None. This should help with matplotlib complaining about too many figures being open at the same time.