### PR TITLE
reduction.py: added data reducer vg_j_parallel

### DIFF
--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -1100,6 +1100,7 @@ v5reducers["vg_reflevel"] =            DataReducerVariable(["CellID"], vg_reflev
 v5reducers["vg_jacobian_b"] =             DataReducerVariable(["vg_dbxvoldx","vg_dbxvoldy","vg_dbxvoldz","vg_dbyvoldx","vg_dbyvoldy","vg_dbyvoldz","vg_dbzvoldx","vg_dbzvoldy","vg_dbzvoldz"], TensorFromScalars, "T/m", 1, latex=r"$\vec{J}$",latexunits=r"$\mathrm{A}\,\mathrm{m}^{-2}$")
 v5reducers["vg_jacobian_bper"] =          DataReducerVariable(["vg_dperbxvoldx","vg_dperbxvoldy","vg_dperbxvoldz","vg_dperbyvoldx","vg_dperbyvoldy","vg_dperbyvoldz","vg_dperbzvoldx","vg_dperbzvoldy","vg_dperbzvoldz"], TensorFromScalars, "T/m", 1, latex=r"$\vec{J}$",latexunits=r"$\mathrm{A}\,\mathrm{m}^{-2}$")
 v5reducers["vg_j"] =                     DataReducerVariable(["vg_jacobian_bper"], J, "A/m^2", 1, latex=r"$\vec{J}$",latexunits=r"$\mathrm{A}\,\mathrm{m}^{-2}$")
+v5reducers["vg_j_parallel"] =                     DataReducerVariable(["vg_j", "vg_b_vol"], ParallelVectorComponent, "A/m^2", 1, latex=r"$J_\parallel$",latexunits=r"$\mathrm{A}\,\mathrm{m}^{-2}$")
 
 
 #multipopv5reducers

--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1676,6 +1676,28 @@ class VlsvReader(object):
 
       .. seealso:: :func:`read` :func:`read_variable_info`
       '''
+
+      # Handle custom variable names
+      # ex. (x-component unit vector Bx/|B|): name = '{vg_b_vol.x} / {vg_b_vol.magnitude}'
+      if '{' in name:
+         name_split = re.split(r"(\{.*?\})", name)
+         var_dct = {}
+         var_count = 0
+         for i, n in enumerate(name_split):
+             if '{' in n:
+                 varname_x = 'var_{}'.format(var_count)
+                 var_op = n[1:-1].split('.')
+                 if len(var_op) == 2:
+                    op = var_op[1]   # note: overrides operator keyword
+                 else:
+                    op = operator
+                 # Recursion: Evaluate variables in '{}'
+                 var_dct[varname_x] = self.read_variable(var_op[0], cellids = cellids, operator = op)
+                 var_count += 1
+                 name_split[i] = varname_x
+         expr = ''.join(name_split)
+         return eval(expr, None, var_dct)
+
       cellids = get_data(cellids)
 
       # Wrapper, check if requesting an fsgrid variable


### PR DESCRIPTION
vlsvreader.py: added capability to read_variable() to read on-the-fly data reducers, if the name string includes terms that look like '{variable_name.operator}'

##

Some comments:

This quick implementation already works remarkably well with other analysator routines---already tested that plot_colormap_3dslice() and and plot_colormap_threeslice() produce the correct plots, with only minor issues in the plot labeling. Also read_interpolated_variable() works with on-the-fly data reducers.

A more robust implementation may require digging into how data reducers work, rather than treating read_variable() as a black box. Lambdas are probably needed to create temporary data reducers.

Also, more secure alternatives to eval() may need to be explored.

