### PR TITLE
Added check to catch masked constants in read_interpolated_variable

### DIFF
--- a/pyVlsv/vlsvreader.py
+++ b/pyVlsv/vlsvreader.py
@@ -1235,7 +1235,9 @@ class VlsvReader(object):
       
       # Check one value for the length
       test_variable = self.read_variable(name,cellids=[1],operator=operator)
-      if isinstance(test_variable, Iterable):
+      if isinstance(test_variable,np.ma.core.MaskedConstant):
+         value_length=1
+      elif isinstance(test_variable, Iterable):
          value_length=len(test_variable)
       else:
          value_length=1


### PR DESCRIPTION
This is a fix for PR #82 :

The problem is that if for any reason the `test_variable` used in `read_interpolated_variable` is masked, `isinstance(test_variable, Iterable)` will return `True` but `value_length=len(test_variable)` will throw the error `TypeError: len() of unsized object`. This is because the masked value is of type `np.ma.core.MaskedConstant`, which inherits the property of `Iterable` from somewhere, but it's actually not iterable.

This PR adds an additional check for `np.ma.core.MaskedConstant` and sets `value_length=1` if the value is masked.