### PR TITLE
Added rudimentary CI workflow for analysator

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -81,6 +81,3 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-
-        


### PR DESCRIPTION
CI for analysator!

Features for now are:
- try to import pytools on latest libraries
- try to import pytools on few Python versions
- Lint with Flake8 (fails, but not enforced for now - there's plenty to pore through)