### PR TITLE
pylab imports replaced with matplotlib.pyplot, as strongly recommended

### DIFF
--- a/examples/plot_VSC.py
+++ b/examples/plot_VSC.py
@@ -3,7 +3,6 @@ import matplotlib
 import matplotlib.colors as colors
 import matplotlib.cm as cmx
 import matplotlib.pyplot as plt
-import pylab as pl
 import numpy as np
 import sys
 import pytools as pt
@@ -63,7 +62,7 @@ for i,time in enumerate(times):
     profiles_T.append(f.read_variable("Temperature", cellids=cellid)*1e-6) #to MK
 
 # Init figure    
-fig = pl.figure()
+fig = plt.figure()
 fig.set_size_inches(6,9)
 
 fig.add_subplot(4,1,1)

--- a/miscellaneous/rankine.py
+++ b/miscellaneous/rankine.py
@@ -23,7 +23,7 @@
 
 # Rankine-Hugoniot conditions to determine the right state from the left state of an MHD oblique shock
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 import sys
 from scipy import optimize
 from cutthrough import cut_through
@@ -222,7 +222,7 @@ def plot_rankine( vlsvReader, point1, point2 ):
    numberOfVariables = len(variables)
 
    fig = plot_variables( distances, variables, figure=[] )
-   pl.show()
+   plt.show()
 
    return fig
 

--- a/pyCalculations/find_x_and_o.py
+++ b/pyCalculations/find_x_and_o.py
@@ -2,7 +2,6 @@
 #
 import pytools as pt
 import numpy as np
-import pylab as pl
 import matplotlib.pyplot as plt
 import sys
 from scipy.ndimage import convolve
@@ -102,7 +101,7 @@ for index in indexes:
    dfdx,dfdz=np.gradient(flux_function)
 
    #calculate the 0 contours of df/dx and df/dz
-   pl.figure(1)
+   plt.figure(1)
    contour1=plt.contour(x_array,z_array, dfdx, [0])
    contour1_paths=contour1.collections[0].get_paths()
    contour2=plt.contour(x_array,z_array, dfdz, [0])
@@ -180,7 +179,7 @@ for index in indexes:
             o_point_location.append(coords)
             o_point_fluxes.append(interpolated_flux)
 
-   pl.close('all')
+   plt.close('all')
 
    np.savetxt(path_to_save+"/o_point_location_"+str(index)+".txt", o_point_location)
    np.savetxt(path_to_save+"/o_point_location_and_fluxes_"+str(index)+".txt", np.concatenate( (o_point_location,np.array(o_point_fluxes)[:,np.newaxis]), axis=1))

--- a/pyCalculations/gyrophaseangle.py
+++ b/pyCalculations/gyrophaseangle.py
@@ -22,7 +22,7 @@
 # 
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from rotation import rotateVectorToVector
 import logging
 
@@ -39,8 +39,8 @@ def gyrophase_angles_from_file( vlsvReader, cellid):
    vlsvReader = VlsvReader("fullf.0001.vlsv")
    result = gyrophase_angles_from_file( vlsvReader=vlsvReader, cellid=1924)
    # Plot the data
-   import pylab as pl
-   pl.hist(result[0].data, weights=result[1].data, bins=100, log=False)
+   import matplotlib.pyplot as plt
+   plt.hist(result[0].data, weights=result[1].data, bins=100, log=False)
    '''
    # Read the velocity cells:
    velocity_cell_data = vlsvReader.read_velocity_cells(cellid)
@@ -95,8 +95,8 @@ def gyrophase_angles(bulk_velocity, B_unit, velocity_cell_data, velocity_coordin
    vlsvReader = VlsvReader("fullf.0001.vlsv")
    result = gyrophase_angles_from_file( vlsvReader=vlsvReader, cellid=1924, cosine=True, plasmaframe=False )
    # Plot the data
-   import pylab as pl
-   pl.hist(result[0].data, weights=result[1].data, bins=100, log=False)
+   import matplotlib.pyplot as plt
+   plt.hist(result[0].data, weights=result[1].data, bins=100, log=False)
    '''
    
    # Get avgs data:
@@ -118,5 +118,5 @@ def gyrophase_angles(bulk_velocity, B_unit, velocity_cell_data, velocity_coordin
    # Return the gyrophase angles and avgs values:
    from output import output_1d
    return output_1d([gyro_angles, avgs], ["Gyrophase_angle", "avgs"], [units, ""])
-   #pl.hist(gyro_angles, weights=avgs, bins=bins, log=log)
+   #plt.hist(gyro_angles, weights=avgs, bins=bins, log=log)
 

--- a/pyCalculations/themis_observation.py
+++ b/pyCalculations/themis_observation.py
@@ -22,7 +22,7 @@
 # 
 
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 import matplotlib
 from rotation import rotateVectorToVector
 from scipy.interpolate import griddata
@@ -126,13 +126,13 @@ def themis_plot_detector(vlsvReader, cellID, detector_axis=np.array([0,1,0]), po
     values = abs(values);
 
     grid_r, grid_theta = np.meshgrid(energies,angles)
-    fig,ax=pl.subplots(subplot_kw=dict(projection="polar"),figsize=(12,10))
+    fig,ax=plt.subplots(subplot_kw=dict(projection="polar"),figsize=(12,10))
     ax.set_title("Detector view at cell " + str(cellID))
     logging.info("Plotting...")
     cax = ax.pcolormesh(grid_theta,grid_r,values, norm=matplotlib.colors.LogNorm(vmin=vmin,vmax=vmax), cmap=themis_colormap)
     ax.grid(True)
     fig.colorbar(cax)
-    pl.show()
+    plt.show()
 
 def themis_plot_phasespace_contour(vlsvReader, cellID, plane_x=np.array([1.,0,0]), plane_y=np.array([0,0,1.]), smooth=False, xlabel="Vx", ylabel="Vy", pop="proton"):
     ''' Plots a contour view of phasespace, as seen by a themis detector, at the given cellID
@@ -167,7 +167,7 @@ def themis_plot_phasespace_contour(vlsvReader, cellID, plane_x=np.array([1.,0,0]
         blurkernel = np.exp(-.17*np.power([6,5,4,3,2,1,0,1,2,3,4,5,6],2))
         vi = sepfir2d(vi, blurkernel, blurkernel) / 4.2983098411528502
 
-    fig,ax=pl.subplots(figsize=(12,10))
+    fig,ax=plt.subplots(figsize=(12,10))
     ax.set_aspect('equal')
     ax.set_title("Phasespace at cell " + str(cellID))
     ax.set_xlabel(xlabel+" (km/s)")
@@ -175,7 +175,7 @@ def themis_plot_phasespace_contour(vlsvReader, cellID, plane_x=np.array([1.,0,0]
     cax = ax.contour(xi,yi,vi.T, levels=np.logspace(np.log10(vmin),np.log10(vmax),20), norm=matplotlib.colors.LogNorm(vmin=vmin,vmax=vmax))
     ax.grid(True)
     fig.colorbar(cax)
-    pl.show()
+    plt.show()
 
 def themis_plot_phasespace_helistyle(vlsvReader, cellID, plane_x=np.array([1.,0,0]), plane_y=np.array([0,0,1.]), smooth=True, xlabel="Vx", ylabel="Vy"):
     ''' Plots a view of phasespace, as seen by a themis detector, at the given cellID, in the style that heli likes.
@@ -210,7 +210,7 @@ def themis_plot_phasespace_helistyle(vlsvReader, cellID, plane_x=np.array([1.,0,
         blurkernel = np.exp(-.17*np.power([6,5,4,3,2,1,0,1,2,3,4,5,6],2))
         vi = sepfir2d(vi, blurkernel, blurkernel) / 4.2983098411528502
 
-    fig,ax=pl.subplots(figsize=(12,10))
+    fig,ax=plt.subplots(figsize=(12,10))
     ax.set_aspect('equal')
     ax.set_title("Phasespace at cell " + str(cellID))
     ax.set_xlabel(xlabel+" (km/s)")
@@ -224,7 +224,7 @@ def themis_plot_phasespace_helistyle(vlsvReader, cellID, plane_x=np.array([1.,0,
     #cax3 = ax.contour(xi,yi,vi.T, levels=np.logspace(np.log10(vmin),np.log10(vmax),20), norm=matplotlib.colors.LogNorm(vmin=vmin,vmax=vmax), cmap=pl.get_cmap("binary"))
     ax.grid(True)
     fig.colorbar(cax)
-    pl.show()
+    plt.show()
 def themis_observation_from_file( vlsvReader, cellid, matrix=np.array([[1,0,0],[0,1,0],[0,0,1]]), countrates=True, interpolate=True,binOffset=[0.,0.],pop='proton'):
    ''' Calculates artificial THEMIS EMS observation from the given cell
    :param vlsvReader:        Some VlsvReader class with a file open

--- a/pyMayaVi/mayavigrid.py
+++ b/pyMayaVi/mayavigrid.py
@@ -32,7 +32,7 @@ from mayavi.tools.mlab_scene_model import \
 from mayavi.core.ui.mayavi_scene import MayaviScene
 import vlsvfile
 from numpy import mgrid, empty, sin, pi, ravel
-import pylab as pl
+import matplotlib.pyplot as plt
 from tvtk.api import tvtk
 import traits.api
 import mayavi.api
@@ -373,8 +373,8 @@ class MayaviGrid(HasTraits):
          from pitchangle import pitch_angles
          result = pitch_angles( vlsvReader=self.vlsvReader, cellid=cellid, cosine=True, plasmaframe=True )
          # plot:
-         pl.hist(result[0].data, weights=result[1].data, bins=50, log=False)
-         pl.show()
+         plt.hist(result[0].data, weights=result[1].data, bins=50, log=False)
+         plt.show()
       elif (self.picker == "Gyrophase_angle"):
          # Find the nearest cell id with distribution:
          # Read cell ids with velocity distribution in:
@@ -400,8 +400,8 @@ class MayaviGrid(HasTraits):
          from gyrophaseangle import gyrophase_angles_from_file
          result = gyrophase_angles_from_file( vlsvReader=self.vlsvReader, cellid=cellid)
          # plot:
-         pl.hist(result[0].data, weights=result[1].data, bins=36, range=[-180.0,180.0], log=True, normed=1)
-         pl.show()
+         plt.hist(result[0].data, weights=result[1].data, bins=36, range=[-180.0,180.0], log=True, normed=1)
+         plt.show()
       elif (self.picker == "Cut_through"):
          # Get the cut-through points
          point1 = self.__last_pick
@@ -446,7 +446,7 @@ class MayaviGrid(HasTraits):
                self.draw_streamline( point1, point2 )
                from plot import plot_multiple_variables
                fig = plot_multiple_variables( distances, variables, figure=[] )
-               pl.show()
+               plt.show()
             # Close the optimized file read:
             self.vlsvReader.optimize_close_file()
             # Read in the necessary variables:

--- a/pyPlots/plot_variables.py
+++ b/pyPlots/plot_variables.py
@@ -29,7 +29,7 @@
 ###############################
 
 
-import pylab as pl
+import matplotlib.pyplot as plt
 import logging
 import numpy as np
 from matplotlib.ticker import MaxNLocator
@@ -135,12 +135,12 @@ def plot_multiple_variables( variables_x_list, variables_y_list, figure=[], clea
    length_of_list = len(variables_x_list)
 
    if figure != []:
-      fig = pl.figure
+      fig = plt.figure()
       if len(fig.get_axes()) < length_of_list:
          for i in (np.arange(length_of_list-len(fig.get_axes())) + len(fig.get_axes())):
             fig.add_subplot(length_of_list,1,i)
    else:
-      fig = pl.figure()
+      fig = plt.figure()
       for i in range(length_of_list):
          fig.add_subplot(length_of_list,1,i+1)
 

--- a/pyVlsv/reduction.py
+++ b/pyVlsv/reduction.py
@@ -25,7 +25,7 @@
 '''
 import logging
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 from reducer import DataReducerVariable
 from rotation import rotateTensorToVector, rotateArrayTensorToVector
 from gyrophaseangle import gyrophase_angles
@@ -698,7 +698,7 @@ def gyrophase_relstddev( variables, velocity_cell_data, velocity_coordinates ):
    B_unit = B / np.linalg.norm(B)
    
    gyrophase_data = gyrophase_angles(bulk_velocity, B_unit, velocity_cell_data, velocity_coordinates)
-   histo = pl.hist(gyrophase_data[0].data, weights=gyrophase_data[1].data, bins=36, range=[-180.0,180.0], log=False, normed=1)
+   histo = plt.hist(gyrophase_data[0].data, weights=gyrophase_data[1].data, bins=36, range=[-180.0,180.0], log=False, normed=1)
    return np.std(histo[0])/np.mean(histo[0])
 
 def Dng( variables ):


### PR DESCRIPTION
From matplotlib:
```quote
[pylab](https://matplotlib.org/stable/api/pylab.html#module-pylab) is a historic interface and its use is strongly discouraged. The equivalent replacement is [matplotlib.pyplot](https://matplotlib.org/stable/api/pyplot_summary.html#module-matplotlib.pyplot). See [Matplotlib Application Interfaces (APIs)](https://matplotlib.org/stable/users/explain/figure/api_interfaces.html#api-interfaces) for a full overview of Matplotlib interfaces.

[pylab](https://matplotlib.org/stable/api/pylab.html#module-pylab) was designed to support a MATLAB-like way of working with all plotting related functions directly available in the global namespace. This was achieved through a wildcard import (from pylab import *).

The use of [pylab](https://matplotlib.org/stable/api/pylab.html#module-pylab) is discouraged for the following reasons:

from pylab import * imports all the functions from [matplotlib.pyplot](https://matplotlib.org/stable/api/pyplot_summary.html#module-matplotlib.pyplot), [numpy](https://numpy.org/doc/stable/reference/index.html#module-numpy), [numpy.fft](https://numpy.org/doc/stable/reference/routines.fft.html#module-numpy.fft), [numpy.linalg](https://numpy.org/doc/stable/reference/routines.linalg.html#module-numpy.linalg), and [numpy.random](https://numpy.org/doc/stable/reference/random/index.html#module-numpy.random), and some additional functions into the global namespace.

Such a pattern is considered bad practice in modern python, as it clutters the global namespace. Even more severely, in the case of [pylab](https://matplotlib.org/stable/api/pylab.html#module-pylab), this will overwrite some builtin functions (e.g. the builtin [sum](https://docs.python.org/3/library/functions.html#sum) will be replaced by [numpy.sum](https://numpy.org/doc/stable/reference/generated/numpy.sum.html#numpy.sum)), which can lead to unexpected behavior.
```