### PR TITLE
Fixing numpy.add 'where' usage in testpackage and examples/generate_panel.py

### DIFF
--- a/examples/generate_panel.py
+++ b/examples/generate_panel.py
@@ -115,19 +115,30 @@ def expr_cav_cust(pass_maps, requestvariables=False):
     empty = np.zeros(np.array(thisrho.shape))
     half = empty + 0.5
     one = empty + 1.0
-    caviton = np.add(empty, one, where=(rhoratio<0.8))
-    caviton = np.add(caviton, one, where=(Bmagratio<0.8))
-    shfa = np.add(caviton, one, where=(thisbeta>10))
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    caviton = np.add(empty, one,out=out_array_temp, where=(rhoratio<0.8))
 
-    combo = np.add(empty, half, where=(caviton>1.5))
-    combo2 = np.add(empty, half, where=(shfa>2.5))
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    caviton = np.add(caviton, one,out=out_array_temp, where=(Bmagratio<0.8))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    shfa = np.add(caviton, one,out=out_array_temp, where=(thisbeta>10))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    combo = np.add(empty, half,out=out_array_temp, where=(caviton>1.5))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    combo2 = np.add(empty, half,out=out_array_temp, where=(shfa>2.5))
     combo3 = combo+combo2
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
 
     # Mask out anything that is inside the bow shock
     bowshock = 2.e6
     combo3 = np.ma.masked_where(thisrho>bowshock, combo3)
 
     return combo3
+
 
 
 

--- a/examples/generate_panel.py
+++ b/examples/generate_panel.py
@@ -115,24 +115,20 @@ def expr_cav_cust(pass_maps, requestvariables=False):
     empty = np.zeros(np.array(thisrho.shape))
     half = empty + 0.5
     one = empty + 1.0
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    caviton = np.add(empty, one,out=out_array_temp, where=(rhoratio<0.8))
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    caviton = np.add(caviton, one,out=out_array_temp, where=(Bmagratio<0.8))
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    shfa = np.add(caviton, one,out=out_array_temp, where=(thisbeta>10))
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    combo = np.add(empty, half,out=out_array_temp, where=(caviton>1.5))
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    combo2 = np.add(empty, half,out=out_array_temp, where=(shfa>2.5))
+ 
+    caviton=np.zeros(empty.shape,dtype='float64')
+    np.add(empty, one,out=caviton, where=(rhoratio<0.8))
+    cavitonbmag=np.zeros(empty.shape,dtype='float64')
+    np.add(caviton, one, out=cavitonbmag,where=(Bmagratio<0.8))
+    shfa=np.zeros(empty.shape,dtype='float64')
+    np.add(cavitonbmag, one,out=shfa, where=(thisbeta>10))
+    
+    combo=np.zeros(empty.shape,dtype='float64')
+    np.add(empty, half,out=combo,where=(cavitonbmag>1.5))
+    combo2=np.zeros(empty.shape,dtype='float64')
+    combo2 = np.add(empty, half,out=combo2, where=(shfa>2.5))
     combo3 = combo+combo2
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-
+    
     # Mask out anything that is inside the bow shock
     bowshock = 2.e6
     combo3 = np.ma.masked_where(thisrho>bowshock, combo3)

--- a/testpackage/testpackage_colormap.py
+++ b/testpackage/testpackage_colormap.py
@@ -179,27 +179,23 @@ def expr_cav_cust(pass_maps, requestvariables=False):
     empty = np.zeros(np.array(thisrho.shape))+0.0
     half = empty + 0.5
     one = empty + 1.0
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    caviton = np.add(empty, one,out=out_array_temp, where=(rhoratio<rhoratioreq))
+    
+    caviton=np.zeros(empty.shape,dtype='float64')
+    np.add(empty, one,out=caviton, where=(rhoratio<rhoratioreq))
     print("sum of cavitons rho ",caviton.sum())
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    caviton = np.add(caviton, one,out=out_array_temp, where=(Bmagratio<bmagratioreq))
-    print("sum of cavitons Bmag ",caviton.sum())
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    shfa = np.add(caviton, one,out=out_array_temp, where=(thisbeta>betashfareq))
+    cavitonbmag=np.zeros(empty.shape,dtype='float64')
+    np.add(caviton, one, out=cavitonbmag,where=(Bmagratio<bmagratioreq))
+    print("sum of cavitons Bmag ",cavitonbmag.sum())
+    shfa=np.zeros(empty.shape,dtype='float64')
+    np.add(cavitonbmag, one,out=shfa, where=(thisbeta>betashfareq))
     print("sum of SHFA ",shfa.sum())
 
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    combo = np.add(empty, half,out=out_array_temp, where=(caviton>1.5))
+    combo=np.zeros(empty.shape,dtype='float64')
+    np.add(empty, half,out=combo,where=(cavitonbmag>1.5))
     print("sum of combo ",combo.sum())
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
-    combo2 = np.add(empty, half,out=out_array_temp, where=(shfa>2.5))
+    combo2=np.zeros(empty.shape,dtype='float64')
+    combo2 = np.add(empty, half,out=combo2, where=(shfa>2.5))
     print("sum of combo2 ",combo2.sum())
-
-    out_array_temp=np.zeros(empty.shape,dtype='float64')
     combo3 = combo+combo2
     print("sum of combo3 ",combo3.sum())
 

--- a/testpackage/testpackage_colormap.py
+++ b/testpackage/testpackage_colormap.py
@@ -179,17 +179,27 @@ def expr_cav_cust(pass_maps, requestvariables=False):
     empty = np.zeros(np.array(thisrho.shape))+0.0
     half = empty + 0.5
     one = empty + 1.0
-    caviton = np.add(empty, one, where=(rhoratio<rhoratioreq))
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    caviton = np.add(empty, one,out=out_array_temp, where=(rhoratio<rhoratioreq))
     print("sum of cavitons rho ",caviton.sum())
-    caviton = np.add(caviton, one, where=(Bmagratio<bmagratioreq))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    caviton = np.add(caviton, one,out=out_array_temp, where=(Bmagratio<bmagratioreq))
     print("sum of cavitons Bmag ",caviton.sum())
-    shfa = np.add(caviton, one, where=(thisbeta>betashfareq))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    shfa = np.add(caviton, one,out=out_array_temp, where=(thisbeta>betashfareq))
     print("sum of SHFA ",shfa.sum())
 
-    combo = np.add(empty, half, where=(caviton>1.5))
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    combo = np.add(empty, half,out=out_array_temp, where=(caviton>1.5))
     print("sum of combo ",combo.sum())
-    combo2 = np.add(empty, half, where=(shfa>2.5))
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
+    combo2 = np.add(empty, half,out=out_array_temp, where=(shfa>2.5))
     print("sum of combo2 ",combo2.sum())
+
+    out_array_temp=np.zeros(empty.shape,dtype='float64')
     combo3 = combo+combo2
     print("sum of combo3 ",combo3.sum())
 


### PR DESCRIPTION
Added `out=` parameter to np.add when `where=` as this causes issues with uninitialized arrays:

From https://numpy.org/doc/2.3/reference/generated/numpy.add.html

"Note that if an uninitialized out array is created via the default out=None, locations within it where the condition is False will remain uninitialized."
