### PR TITLE
Added writing of the commit hash into miscellaneous._commithash when installing analysator

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -40,7 +40,6 @@ jobs:
         python -c 'import analysator as pt;pt.calculations.__dict__'
         python -c 'import analysator as pt;pt.vlsvfile.__dict__'
         python -c 'import analysator as pt;pt.miscellaneous.__dict__'
-        python -c 'import vlsvrs'
 
 
   ubuntu_22_04_versions_3_9:
@@ -77,7 +76,6 @@ jobs:
         python -c 'import analysator as pt;pt.calculations.__dict__'
         python -c 'import analysator as pt;pt.vlsvfile.__dict__'
         python -c 'import analysator as pt;pt.miscellaneous.__dict__'
-        python -c 'import vlsvrs'
 
   ubuntu_22_04_version_3_7:
 

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -40,6 +40,7 @@ jobs:
         python -c 'import analysator as pt;pt.calculations.__dict__'
         python -c 'import analysator as pt;pt.vlsvfile.__dict__'
         python -c 'import analysator as pt;pt.miscellaneous.__dict__'
+        python -c 'import vlsvrs'
 
 
   ubuntu_22_04_versions_3_9:
@@ -76,6 +77,7 @@ jobs:
         python -c 'import analysator as pt;pt.calculations.__dict__'
         python -c 'import analysator as pt;pt.vlsvfile.__dict__'
         python -c 'import analysator as pt;pt.miscellaneous.__dict__'
+        python -c 'import vlsvrs'
 
   ubuntu_22_04_version_3_7:
 
@@ -103,6 +105,7 @@ jobs:
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
             python -c 'import analysator as pt;pt.miscellaneous.__dict__'
+            python -c 'import vlsvrs'
 
       
 

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -105,7 +105,6 @@ jobs:
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
             python -c 'import analysator as pt;pt.miscellaneous.__dict__'
-            python -c 'import vlsvrs'
 
       
 

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -45,5 +45,6 @@ jobs:
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
             python -c 'import analysator as pt;pt.miscellaneous.__dict__'
+            python -c 'import vlsvrs'
 
             

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -45,6 +45,5 @@ jobs:
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
             python -c 'import analysator as pt;pt.miscellaneous.__dict__'
-            python -c 'import vlsvrs'
 
             

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -44,6 +44,5 @@ jobs:
             python -c 'import analysator as pt;pt.plot.__dict__'
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
-            python -c 'import analysator as pt;pt.miscellaneous.__dict__'
-
+            python -c 'import analysator as pt;pt.miscellaneous.__dict__;print(pt.miscellaneous._commithash.commithash)'
             

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -44,5 +44,5 @@ jobs:
             python -c 'import analysator as pt;pt.plot.__dict__'
             python -c 'import analysator as pt;pt.calculations.__dict__'
             python -c 'import analysator as pt;pt.vlsvfile.__dict__'
-            python -c 'import analysator as pt;pt.miscellaneous.__dict__;print(pt.miscellaneous._commithash.commithash)'
-            
+            python -c 'import analysator as pt;pt.miscellaneous.__dict__;import analysator.miscellaneous._commithash as chash; print(chash.commithash)'
+

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,4 +1,3 @@
-from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 import sys, subprocess
 from packaging.version import Version
 # import logging
@@ -6,6 +5,7 @@ from packaging.version import Version
 import platform
 if not Version(platform.python_version()) < Version("3.8"):
         
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
     class CustomBuildHook(BuildHookInterface):
         def initialize(self,*param,**kwargs):
             with open("./analysator/miscellaneous/_commithash.py","w") as file:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -9,7 +9,7 @@ class CustomBuildHook(BuildHookInterface):
             file.write(f"commithash='{commithash.strip('\n')}'\n")
             file.close()
        
-    def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str)->None:
+    def finalize(self, *param,**kwargs)->None:
         out=subprocess.run([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt","-v"],capture_output=True,check=True)
         #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
         #print(out) #Also doesnt work

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -6,7 +6,8 @@ class CustomBuildHook(BuildHookInterface):
     def initialize(self,*param,**kwargs):
         with open("./analysator/miscellaneous/_commithash.py","w") as file:
             commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
-            file.write(f"commithash='{commithash.strip('\n')}'"+"\n")
+            commithash=commithash.strip("\n")
+            file.write(f"commithash='{commithash}'"+"\n")
             file.close()
        
     def finalize(self, *param,**kwargs)->None:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,24 +1,12 @@
 import sys, subprocess
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging.version import Version
-# import logging
-# logger = logging.getLogger(__name__)
-import platform
-if not Version(platform.python_version()) < Version("3.8"):
-        
-    class CustomBuildHook(BuildHookInterface):
-        def initialize(self,*param,**kwargs):
-            with open("./analysator/miscellaneous/_commithash.py","w") as file:
-                commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
-                commithash=commithash.strip("\n")
-                file.write(f"commithash='{commithash}'"+"\n")
-                file.close()
-           
-        def finalize(self, *param,**kwargs)->None:
-            out=subprocess.run([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt","-v"],capture_output=True,check=True)
-            #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
-            #print(out) #Also doesnt work
-            # self.app.display_error(out.stdout.decode('utf-8')) #Does not work
-else:
-    class CustomBuildHook(BuildHookInterface):
-        print("eh")
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self,*param,**kwargs):
+        with open("./analysator/miscellaneous/_commithash.py","w") as file:
+            commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
+            commithash=commithash.strip("\n")
+            file.write(f"commithash='{commithash}'"+"\n")
+            file.close()
+

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -2,6 +2,9 @@ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 import sys, subprocess
 # import logging
 # logger = logging.getLogger(__name__)
+import platform
+if Version(platform.python_version()) <= Version("3.7"):
+    quit()
 class CustomBuildHook(BuildHookInterface):
     def initialize(self,*param,**kwargs):
         with open("./analysator/miscellaneous/_commithash.py","w") as file:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,11 +1,11 @@
 import sys, subprocess
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging.version import Version
 # import logging
 # logger = logging.getLogger(__name__)
 import platform
 if not Version(platform.python_version()) < Version("3.8"):
         
-    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
     class CustomBuildHook(BuildHookInterface):
         def initialize(self,*param,**kwargs):
             with open("./analysator/miscellaneous/_commithash.py","w") as file:
@@ -19,3 +19,6 @@ if not Version(platform.python_version()) < Version("3.8"):
             #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
             #print(out) #Also doesnt work
             # self.app.display_error(out.stdout.decode('utf-8')) #Does not work
+else:
+    class CustomBuildHook(BuildHookInterface):
+        print("eh")

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,6 +1,16 @@
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 import sys, subprocess
+# import logging
+# logger = logging.getLogger(__name__)
 class CustomBuildHook(BuildHookInterface):
-    
-    def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt"])
+    def initialize(self,*param,**kwargs):
+        with open("./analysator/miscellaneous/_commithash.py","w") as file:
+            commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
+            file.write(f"commithash='{commithash.strip('\n')}'\n")
+            file.close()
+       
+    def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str)->None:
+        out=subprocess.run([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt","-v"],capture_output=True,check=True)
+        #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
+        #print(out) #Also doesnt work
+        # self.app.display_error(out.stdout.decode('utf-8')) #Does not work

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,7 +4,7 @@ from packaging.version import Version
 # import logging
 # logger = logging.getLogger(__name__)
 import platform
-if Version(platform.python_version()) <= Version("3.7"):
+if Version(platform.python_version()) < Version("3.8"):
     quit()
 class CustomBuildHook(BuildHookInterface):
     def initialize(self,*param,**kwargs):

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,5 +1,6 @@
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 import sys, subprocess
+from packaging.version import Version
 # import logging
 # logger = logging.getLogger(__name__)
 import platform

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -4,18 +4,18 @@ from packaging.version import Version
 # import logging
 # logger = logging.getLogger(__name__)
 import platform
-if Version(platform.python_version()) < Version("3.8"):
-    quit()
-class CustomBuildHook(BuildHookInterface):
-    def initialize(self,*param,**kwargs):
-        with open("./analysator/miscellaneous/_commithash.py","w") as file:
-            commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
-            commithash=commithash.strip("\n")
-            file.write(f"commithash='{commithash}'"+"\n")
-            file.close()
-       
-    def finalize(self, *param,**kwargs)->None:
-        out=subprocess.run([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt","-v"],capture_output=True,check=True)
-        #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
-        #print(out) #Also doesnt work
-        # self.app.display_error(out.stdout.decode('utf-8')) #Does not work
+if not Version(platform.python_version()) < Version("3.8"):
+        
+    class CustomBuildHook(BuildHookInterface):
+        def initialize(self,*param,**kwargs):
+            with open("./analysator/miscellaneous/_commithash.py","w") as file:
+                commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
+                commithash=commithash.strip("\n")
+                file.write(f"commithash='{commithash}'"+"\n")
+                file.close()
+           
+        def finalize(self, *param,**kwargs)->None:
+            out=subprocess.run([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt","-v"],capture_output=True,check=True)
+            #logger.error("TESTINGTESTING ALERTA"+out.stdout.decode('utf-8')) #Doesnt work
+            #print(out) #Also doesnt work
+            # self.app.display_error(out.stdout.decode('utf-8')) #Does not work

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -6,7 +6,7 @@ class CustomBuildHook(BuildHookInterface):
     def initialize(self,*param,**kwargs):
         with open("./analysator/miscellaneous/_commithash.py","w") as file:
             commithash=subprocess.run(["git","rev-parse","HEAD"],capture_output=True).stdout.decode('utf-8')
-            file.write(f"commithash='{commithash.strip('\n')}'\n")
+            file.write(f"commithash='{commithash.strip('\n')}'"+"\n")
             file.close()
        
     def finalize(self, *param,**kwargs)->None:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,6 @@
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+import sys, subprocess
+class CustomBuildHook(BuildHookInterface):
+    
+    def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r","requirements-backend.txt"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling","pip"]
 build-backend = "hatchling.build"
 
 
@@ -51,6 +51,7 @@ vlsvrs_build = [
 [project.urls]
 Homepage = "https://github.com/fmihpc/analysator"
 Issues = "https://github.com/fmihpc/analysator/issues"
+[tool.hatch.build.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
 packages = ["./analysator","./pytools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ vlsvrs_build = [
 [project.urls]
 Homepage = "https://github.com/fmihpc/analysator"
 Issues = "https://github.com/fmihpc/analysator/issues"
+
 [tool.hatch.build.hooks.custom]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Adds the hook script to hatchling build to make a filed `_commithash.py` in miscellaneous that has the commithash in it: 
```Python
from analysator.miscellaneous._commithash import *
print(commithash)
```
