### PR TITLE
Function to extract pathline/streakline matrix from seed points

### DIFF
--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -407,7 +407,7 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
    return points_traced       # list for fg; 3d numpy array(N,maxiterations,3) for vg
 
 
-def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= False):
+def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= False, integration_steps = 1):
    """
    form a (N, T, T, 3) matrix where N: number of seed points, T: number of timesteps, and 3D coordinates
    Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
@@ -422,6 +422,14 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
    keep track of current position using current_pos = (N,T,3)
    """
 
+   if direction == "both":
+      M_plus = streaklines_3D(files_list, seed_points, direction="+", is_test=is_test)
+      M_minus = streaklines_3D(files_list, seed_points, direction="-", is_test=is_test)
+      M_both =  np.nansum(np.stack([M_plus,M_minus], axis = 0),axis = 0)
+      #fix diagonal
+      for t in range(len(files_list)):
+         M_both[:,t,t,:] = M_plus[:,t,t,:]
+      return M_both
    #number of time steps
    T = len(files_list)
    #number of seed points
@@ -454,10 +462,11 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
       
       if direction == "+":
          current_cols = range(0,file_index+1)
-      else:
+      
+      elif direction == "-":
          #negative direction
          current_cols = range(file_index,T)
-
+      
       #record current positions
       for n in range(N):
          for j in current_cols:
@@ -479,10 +488,6 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
       n_idx, j_idx = np.meshgrid(ns,js, indexing = "ij")
       n_idx = n_idx.ravel()
       j_idx = j_idx.ravel()
-      positions = current_pos[n_idx,j_idx, :]
-
-      velocities = vlsvfile.read_interpolated_variable("vg_v",positions)
-
 
       #read next vlsvfile for time
       next_file = file_index + 1 if direction == "+" else file_index - 1
@@ -491,8 +496,24 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
       
       dt = abs(t_1-t_0)
 
-      #calculate new positions 
-      current_pos[n_idx, j_idx, :] += sign*velocities*dt
+      if integration_steps == 1:
+
+         positions = current_pos[n_idx,j_idx, :]
+
+         velocities = vlsvfile.read_interpolated_variable("vg_v",positions)
+
+         #calculate new positions 
+         current_pos[n_idx, j_idx, :] += sign*velocities*dt
+      else: 
+         #reads interpolated time between vlsvfiles for more accurate integration
+         dt_step = dt/integration_steps
+
+         for step in range(integration_steps):
+
+            t_step = t_0 + dt_step*step
+            positions = current_pos[n_idx,j_idx, :]
+            velocities = pt.calculations.timeevolution.get_interpolated_variable(vlsvfile,next_vslv, "vg_v", positions,t_step)
+            current_pos[n_idx,j_idx, :] += sign*velocities*dt_step
 
       #set next points as current points for the next looping
       t_0 = t_1

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -406,3 +406,100 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
 
    return points_traced       # list for fg; 3d numpy array(N,maxiterations,3) for vg
 
+
+def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= False):
+   """
+   form a (N, T, T, 3) matrix where N: number of seed points, T: number of timesteps, and 3D coordinates
+   Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
+   i=j gives the seed point/release point where particles are started to track 
+   algorithm forward: 
+      -open file i
+      -place particle in i=j
+      -record all particle positions
+      -move all particles j<=i according to velocity at time i
+         -current_pos += velocity*dt
+      loop till end
+   keep track of current position using current_pos = (N,T,3)
+   """
+
+   #number of time steps
+   T = len(files_list)
+   #number of seed points
+   N = len(seed_points)
+
+   #Full matrix that is filled with coordinates 
+   M = np.full((N,T,T,3), np.nan)
+
+   sign = 1 if direction == "+" else -1
+   #records the current positions of the tracked plasma
+   current_pos = np.full((N,T,3), np.nan)
+
+   file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
+
+   for i, file_index in enumerate(file_indices):
+
+      if i == 0:
+         #initial file read and timestep
+         if is_test:
+            print("test")
+            t_0 = 0
+         else:   
+            vlsvfile = pt.vlsvfile.VlsvReader(files_list[file_index])
+            t_0 = vlsvfile.read_parameter("time")
+      for n in range(N):
+
+         current_pos[n, file_index,:] = seed_points[n]
+         #Diagonal point so initial point
+         M[n, file_index, file_index,:] = seed_points[n]
+      
+      if direction == "+":
+         current_cols = range(0,file_index+1)
+      else:
+         #negative direction
+         current_cols = range(file_index,T)
+
+      #record current positions
+      for n in range(N):
+         for j in current_cols:
+            M[n,file_index,j,:] = current_pos[n,j,:] 
+      if i == T-1:
+         #On last step return the matrix and dont continue the integration
+         return M
+
+      #INTEGRATION STARTS HERE
+      #first record the current velocities 
+      if direction == "+":
+         js = np.arange(0,file_index+1)
+      else:
+         #negative direction
+         js = np.arange(file_index,T)
+         
+
+      ns = np.arange(N)
+      n_idx, j_idx = np.meshgrid(ns,js, indexing = "ij")
+      n_idx = n_idx.ravel()
+      j_idx = j_idx.ravel()
+      positions = current_pos[n_idx,j_idx, :]
+
+      velocities = vlsvfile.read_interpolated_variable("vg_v",positions)
+
+
+      #read next vlsvfile for time
+      next_file = file_index + 1 if direction == "+" else file_index - 1
+      next_vslv = pt.vlsvfile.VlsvReader(files_list[next_file])
+      t_1 = next_vslv.read_parameter("time")
+      
+      dt = abs(t_1-t_0)
+
+      #calculate new positions 
+      current_pos[n_idx, j_idx, :] += sign*velocities*dt
+
+      #set next points as current points for the next looping
+      t_0 = t_1
+      vlsvfile = next_vslv 
+      
+
+   
+   #Back up return M 
+   return M #matrix of form shape = (N, T, T, 3)
+

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -409,7 +409,7 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
 
 def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
    """
-   forms a (N, T*P+1-P, T*S+1-S, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, S: seeds per timestep, and 3D coordinates
+   forms a (N, T*P+1-P, T*P+1-P, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, and 3D coordinates
    Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
    i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
    algorithm forward: 
@@ -419,7 +419,7 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
       -move all particles j<=i according to velocity at time i
          -current_pos += velocity*dt
       loop till end
-   keep track of current position using current_pos = (N,T,3)
+   keep track of current position using current_pos = (N,T*P,3)
 
       param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
       param files_list:    List containing paths to VLSV files
@@ -446,13 +446,21 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
    #number of seed points
    N = len(seed_points)
 
-   T_eff = T*points_per
+   T_eff = T*points_per-points_per+1
    record_point = integration_steps//points_per
+
+   #Also just prefill diagonal with seed points.
+   #No need to have it in the actual loops
+   #prepping functions for polishing code
+   def active_indices():
+      return
+   def inject_record():
+      return
 
    if direction == "both":
       
-      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps)
-      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps)
+      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps, points_per = points_per, var = var)
+      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps, points_per = points_per, var = var)
       M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
 
       #fix diagonal
@@ -461,11 +469,11 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
       return M_both
 
    #Full matrix to be filled with coordinates 
-   M = np.full((N, T_eff-points_per+1, T, 3), np.nan)
+   M = np.full((N, T_eff, T_eff, 3), np.nan)
 
    sign = 1 if direction == "+" else -1
    #records the current positions of the tracked plasma
-   current_pos = np.full((N, T, 3), np.nan)
+   current_pos = np.full((N, T_eff, 3), np.nan)
 
    file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
 
@@ -479,18 +487,19 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
          vlsvfile  = vlsvTObject.readers[file_index]
          t_0 = vlsvTObject.ts[file_index]
 
+      #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
       #injecting points
       for n in range(N):
-         current_pos[n, file_index,:] = seed_points[n]
+         current_pos[n, eff_file_index,:] = seed_points[n]
          #Diagonal point so initial point
-         M[n, eff_file_index, file_index,:] = seed_points[n]
-      
+         M[n, eff_file_index, eff_file_index,:] = seed_points[n]
+
       if direction == "+":
-         current_cols = range(0, file_index+1)
+         current_cols = range(0, eff_file_index+1)
       
       elif direction == "-":
          #negative direction
-         current_cols = range(file_index, T)
+         current_cols = range(eff_file_index, T_eff)
       
       #record current positions
       for n in range(N):
@@ -502,14 +511,6 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
          return M #matrix of form shape = (N, T, T, 3)
 
       #INTEGRATION
-
-      #first record the current velocities 
-      if direction == "+":
-         js = np.arange(0, file_index + 1)
-      else:
-         #negative direction
-         js = np.arange(file_index, T)
-     
 
       #read next vlsvfile for time
       next_file = file_index + 1 if direction == "+" else file_index - 1
@@ -523,6 +524,13 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
       #reads interpolated time between vlsvfiles
       #dt*dt_step is integration step size 
       dt_step = dt/integration_steps
+
+      #first record the current velocities 
+      if direction == "+":
+         js = np.arange(0, eff_file_index + 1)
+      else:
+         #negative direction
+         js = np.arange(eff_file_index, T_eff)
           
       ns = np.arange(N)
       n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
@@ -540,20 +548,39 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
 
          if (step+1)% record_point == 0:
             record_idx = (step+1)//record_point
-            eff_idx = eff_file_index + record_idx
-
-            if direction == "+":
-               current_cols = range(0, file_index+1)
+            eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx
+            print(t_step)
+            if record_idx == points_per:
+               #skip here since recorded at the beginning of the next loop
+               #structure could be improved? 
+               continue
+               
+            #adding seed points between timesteps 
+            for n in range(N):
+               current_pos[n,eff_idx,:] = seed_points[n]
+               M[n,eff_idx, eff_idx, :] = seed_points[n]
             
+            if direction == "+":
+               js = np.arange(0,eff_idx+1)
+
             elif direction == "-":
                #negative direction
-               current_cols = range(file_index, T)
+               js = np.arange(eff_idx, T_eff)
             
-            #record current positions
+            #preps indeces for next loop
+            n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
+            n_idx = n_idx.ravel()
+            j_idx = j_idx.ravel()
+            
+            if direction == "+":
+               rec_cols = range(0, eff_idx+1)
+            elif direction == "-":
+               rec_cols = range(eff_idx, T_eff)
+            
+            #record current positions between timesteps 
             for n in range(N):
-               for j in current_cols:
+               for j in rec_cols:
                   M[n,eff_idx,j,:] = current_pos[n,j,:] 
-
 
       #set next points as current points for the next looping
       t_0 = t_1

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -411,6 +411,16 @@ class streaklines:
    """
    Class to analyze temporal pathlines and streaklines between a range of Vlasiator time steps
 
+   param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
+   param files_list:    List containing paths to VLSV files
+   param seed_points:   list of seed points for streaklines (meters)
+   param direction:     direction of integration (+,-, both)
+   param dt_step:       time step size of integration 
+   param var:           integration variable
+   param method:        integration step method (euler, RK4)
+   param point_recorded:Number of total recorded points
+   param points_per:    Alternative to points_recorded. Number of points recorded per time step
+
    Example Use to create plot showing pathline of an released particle 
    and the streakline of the fluid over the entire time period: 
 
@@ -430,18 +440,6 @@ class streaklines:
    """
 
    def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler"):
-      """
-      Initiation of class 
-      param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
-      param files_list:    List containing paths to VLSV files
-      param seed_points:   list of seed points for streaklines (meters)
-      param direction:     direction of integration (+,-, both)
-      param dt_step:       time step size of integration 
-      param var:           integration variable
-      param method:        integration step method (euler, RK4)
-      param point_recorded:Number of total recorded points
-      param points_per:    Alternative to points_recorded. Number of points recorded per time step
-      """
 
       self.dt_step = dt_step
       self.method = method
@@ -481,14 +479,7 @@ class streaklines:
       Code uses Euler or RK4  method to conduct the tracing.
       Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
       i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
-      algorithm forward: 
-         -open file i
-         -place particle in i=j
-         -record all particle positions
-         -move all particles j<=i according to velocity at time i
-            -current_pos += velocity*dt
-         loop till end
-      keep track of current position using current_pos = (N,T*P,3)
+      Current position of particles kept track using current_pos = (N,T*P,3)
          
          param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
          param files_list:    List containing paths to VLSV files
@@ -502,8 +493,6 @@ class streaklines:
       returns: (N, T*P+1-P, T*P+1-P, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, and 3D coordinates
       """
 
-      import math
-
       #Initial input checks
       if (vlsvTObject is None) and (files_list is None):
          raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
@@ -511,13 +500,11 @@ class streaklines:
          raise ValueError("Please only provide one source of files")
       if (seed_points is None):
          raise ValueError("Please provide seed points")
-   
 
       if files_list is not None: 
          #adding as readers since VlsvTInterpolator has no caching 
          readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
          vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
-         #vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
       #number of time steps
       T = len(vlsvTObject.files)
@@ -569,18 +556,18 @@ class streaklines:
             v = 1/6*(k1 + 2*k2 + 2*k3 + k4)
          else:
             raise ValueError("not a valid integrations type")
-         
-         #update current particle positions according to the step
+             
          v = v.reshape(-1,3)
-         """
+         
+         #Limit max step size taken in one integration step
          if np.any(np.linalg.norm(dt_s*v,axis=1)>max_dx):
             #recursively add additional two half sized integration steps 
             integration_step(t_step, dt_s/2, n_idx, j_idx, method=method)
             integration_step(t_step+sign*dt_s/2, dt_s/2, n_idx, j_idx, method = method)
             
             return
-         """
-         #print(np.max(np.linalg.norm(dt_s*v,axis=1)))
+         
+         #update current particle positions according to the step
          current_pos[n_idx, j_idx, :] += sign*dt_s*v
 
 
@@ -646,7 +633,7 @@ class streaklines:
          |-------|-------|-------|----|
          """
          #number of integration steps
-         steps = math.ceil(dt/dt_step) 
+         steps = self.math.ceil(dt/dt_step) 
          t_elapsed = 0.0
          prev_record_idx = 0
 
@@ -724,159 +711,3 @@ class streaklines:
 
       return streakline 
 
-
-def pathlines(vlsvTObject = None, files_list = None, seed_points = None, direction = "+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", tracked_vars = None, method = "euler"):
-   """
-   Function to track the pathlines of plasma parcels and their features ("vg_b_vol", "proton/vg_beta_star" etc.)
-   Scales better than streaklines class if pathlines are of only interest.
-   Example use:
-   seed = [1e8, 0, 0]
-   files_list = ["./bulk1.0001300.vlsv","./bulk1.00013005.vlsv"]
-   pathslines, tracked_vars = pt.calculations.fieldtracer.pathlines(files_list = files_list, seed_points = seed,
-                                                                   tracked_vars = ["vg_b_vol", "proton/vg_beta_star"])
-   magnetic_field_data = tracked_vars["vg_b_vol"]
-   --> cool plots
-   """ 
-   import math
-
-   if (vlsvTObject is None) and (files_list is None):
-         raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
-   elif (vlsvTObject is not None) and (files_list is not None):
-      raise ValueError("Please only provide one source of files")
-   if (seed_points is None):
-      raise ValueError("Please provide seed points")
-
-   if files_list is not None: 
-      #adding as readers since VlsvTInterpolator has no caching 
-      readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
-      vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
-
-   #Defining the amount of point recorded per timestep as the total wanted recorded points 
-   #divided by the amount of time steps
-   if points_recorded is not None:
-      points_per = int(math.ceil(points_recorded/len(vlsvTObject.ts)))
-   else:
-      points_per = points_per
-   
-   #initial sanity check to make sure integration steps > points recorded per time step:
-   if points_per > math.ceil(abs(vlsvTObject.ts[1]-vlsvTObject.ts[0])/dt_step):
-      raise ValueError("Trying to record more points than there are integration steps. Consider lowering recorded points or decreasing dt_step")
-   
-   #number of time steps
-   T = len(vlsvTObject.files)
-   #number of seed points
-   N = len(seed_points)
-   #effective number of time steps due to inbetween recordings
-   T_eff = T*points_per-points_per+1
-
-   pathline_obj = np.full((N, T_eff, 3), np.nan)
-   
-   
-   #records the current positions of the tracked plasma
-   current_pos = np.array(seed_points,dtype = float)
-
-   tracked_objs = {}
-   if tracked_vars is not None:
-      for tracked_var in tracked_vars:
-         test_val = np.array(vlsvTObject(vlsvTObject.ts[0], current_pos, tracked_var))
-         if test_val.ndim == 0:
-            test_val = test_val.reshape(1)
-         if test_val.shape[0] !=N:
-            test_val = test_val.reshape(N,-1)
-         var_shape = test_val.shape[1:]
-         tracked_objs[tracked_var] = np.full((N,T_eff) + var_shape, np.nan)
-         print(tracked_objs[tracked_var].shape)
-         
-   def _get_var(t, positions, var):
-      result = vlsvTObject(t, positions, var)
-      if result.ndim == 0:
-         result = result.reshape(1)
-      if result.shape[0] !=N:
-         result = result.reshape(N,-1)
-      return result
-
-   def integration_step(t_step, dt_s, current_pos,  method = method):
-         #dt_s*v is the displacement amount in a integration step
-         """
-         pram t_step: time step is taken
-         pram dt_s:   size of the integration step
-         pram n_idx:  seed point index array
-         pram j_idx:  release time index array
-
-         """
-
-         positions = current_pos
-
-         if method == "euler":
-            #classic euler step method of integration
-            v =  _get_var(t_step, positions,var)
-         elif method == "RK4":
-            #runge-kutta 4 integration method, see: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
-            k1 = _get_var(t_step, positions, var)
-            k2 = _get_var(t_step + dt_s/2, positions + sign*k1*dt_s/2, var)
-            k3 = _get_var(t_step + dt_s/2, positions + sign*k2*dt_s/2, var)
-            k4 = _get_var(t_step + dt_s, positions + sign*dt_s*k3, var)
-            v = 1/6*(k1 + 2*k2 + 2*k3 + k4)
-         else:
-            raise ValueError("not a valid integrations type")
-         
-         #update current particle positions according to the step
-         v = v.reshape(-1,3)
-         """
-         if np.any(np.linalg.norm(dt_s*v,axis=1)>max_dx):
-            #recursively add additional two half sized integration steps 
-            integration_step(t_step, dt_s/2, n_idx, j_idx, method=method)
-            integration_step(t_step+sign*dt_s/2, dt_s/2, n_idx, j_idx, method = method)
-            
-            return
-         """
-         #print(np.max(np.linalg.norm(dt_s*v,axis=1)))
-         current_pos += sign*dt_s*v
-   
-   sign = 1 if direction == "+" else -1
-
-   file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
-
-   #MAIN LOOP
-   for i, file_index in enumerate(file_indices):
-
-      eff_file_index = file_index*points_per
-
-      t_0 = vlsvTObject.ts[file_index]
-
-      pathline_obj[:,eff_file_index,:] = current_pos
-      if tracked_vars is not None:
-         for tracked_var in tracked_vars:
-            tracked_objs[tracked_var][:,eff_file_index] = _get_var(t_0, current_pos, tracked_var)
-
-      if i == T-1:
-         break
-
-      next_file = file_index +1 if direction == "+" else file_index-1
-      t_1 = vlsvTObject.ts[next_file]
-      dt = abs(t_1-t_0)
-      
-      steps  = math.ceil(dt/dt_step)
-      t_elapsed = 0.0
-      prev_record_idx = 0
-
-      for step in range(steps):
-
-         t_step = t_0 + t_elapsed*sign
-         actual_dt = min(dt_step, dt-t_elapsed)
-
-         integration_step(t_step, actual_dt, current_pos, method = method)
-
-         t_elapsed += actual_dt
-
-         record_idx = int((t_elapsed)/dt*points_per)
-         if record_idx != prev_record_idx and record_idx < points_per:
-         
-               prev_record_idx = record_idx
-               eff_idx = eff_file_index + record_idx*sign  
-               pathline_obj[:,eff_idx,:] = current_pos
-               if tracked_vars is not None:
-                  for tracked_var in tracked_vars:
-                     tracked_objs[tracked_var][:,eff_idx] = _get_var(t_0+t_elapsed, current_pos, tracked_var)
-               
-   return pathline_obj, tracked_objs

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -407,11 +407,11 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
    return points_traced       # list for fg; 3d numpy array(N,maxiterations,3) for vg
 
 
-def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, direction="+", integration_steps = 10, var = "vg_v"):
+def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
    """
-   forms a (N, T, T, 3) matrix where N: number of seed points, T: number of timesteps, and 3D coordinates
+   forms a (N, T*P+1-P, T*S+1-S, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, S: seeds per timestep, and 3D coordinates
    Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
-   i=j gives the seed point/release point where particles are started to track 
+   i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
    algorithm forward: 
       -open file i
       -place particle in i=j
@@ -421,6 +421,7 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       loop till end
    keep track of current position using current_pos = (N,T,3)
 
+      param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
       param files_list:    List containing paths to VLSV files
       param seed_points:   list of seed points for streaklines (meters)
       param direction:     direction of integration (+,-, both)
@@ -445,6 +446,9 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
    #number of seed points
    N = len(seed_points)
 
+   T_eff = T*points_per
+   record_point = integration_steps//points_per
+
    if direction == "both":
       
       M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps)
@@ -452,12 +456,12 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
 
       #fix diagonal
-      for t in range(T):
+      for t in range(T_eff):
          M_both[:,t,t,:] = M_plus[:,t,t,:]
       return M_both
 
    #Full matrix to be filled with coordinates 
-   M = np.full((N, T, T, 3), np.nan)
+   M = np.full((N, T_eff-points_per+1, T, 3), np.nan)
 
    sign = 1 if direction == "+" else -1
    #records the current positions of the tracked plasma
@@ -467,16 +471,19 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
 
    for i, file_index in enumerate(file_indices):
 
+      eff_file_index = file_index*points_per
+
       if i == 0:
          #initial file read and timestep
          
          vlsvfile  = vlsvTObject.readers[file_index]
          t_0 = vlsvTObject.ts[file_index]
 
+      #injecting points
       for n in range(N):
          current_pos[n, file_index,:] = seed_points[n]
          #Diagonal point so initial point
-         M[n, file_index, file_index,:] = seed_points[n]
+         M[n, eff_file_index, file_index,:] = seed_points[n]
       
       if direction == "+":
          current_cols = range(0, file_index+1)
@@ -488,7 +495,7 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       #record current positions
       for n in range(N):
          for j in current_cols:
-            M[n,file_index,j,:] = current_pos[n,j,:] 
+            M[n,eff_file_index,j,:] = current_pos[n,j,:] 
 
       if i == T-1:
          #On last step return the matrix and dont continue the integration
@@ -502,11 +509,7 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       else:
          #negative direction
          js = np.arange(file_index, T)
-         
-      ns = np.arange(N)
-      n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
-      n_idx = n_idx.ravel()
-      j_idx = j_idx.ravel()
+     
 
       #read next vlsvfile for time
       next_file = file_index + 1 if direction == "+" else file_index - 1
@@ -520,6 +523,11 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       #reads interpolated time between vlsvfiles
       #dt*dt_step is integration step size 
       dt_step = dt/integration_steps
+          
+      ns = np.arange(N)
+      n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
+      n_idx = n_idx.ravel()
+      j_idx = j_idx.ravel()
 
       for step in range(integration_steps):
 
@@ -529,6 +537,23 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
          velocities = vlsvTObject(t_step, positions, var)
          
          current_pos[n_idx, j_idx, :] += sign*velocities*dt_step
+
+         if (step+1)% record_point == 0:
+            record_idx = (step+1)//record_point
+            eff_idx = eff_file_index + record_idx
+
+            if direction == "+":
+               current_cols = range(0, file_index+1)
+            
+            elif direction == "-":
+               #negative direction
+               current_cols = range(file_index, T)
+            
+            #record current positions
+            for n in range(N):
+               for j in current_cols:
+                  M[n,eff_idx,j,:] = current_pos[n,j,:] 
+
 
       #set next points as current points for the next looping
       t_0 = t_1

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -407,153 +407,170 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
    return points_traced       # list for fg; 3d numpy array(N,maxiterations,3) for vg
 
 
-def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
-   """
-   forms a (N, T*P+1-P, T*P+1-P, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, and 3D coordinates
-   Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
-   i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
-   algorithm forward: 
-      -open file i
-      -place particle in i=j
-      -record all particle positions
-      -move all particles j<=i according to velocity at time i
-         -current_pos += velocity*dt
-      loop till end
-   keep track of current position using current_pos = (N,T*P,3)
+class streaklines: 
 
-      param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
-      param files_list:    List containing paths to VLSV files
-      param seed_points:   list of seed points for streaklines (meters)
-      param direction:     direction of integration (+,-, both)
-      param integration_steps:   number of integration steps between each timestep
-      param var:           integration variable
+   def __init__(self):
+      self.M = "matrix here"
+      pass
 
-   """
-  
-   if (vlsvTObject is None) and (files_list is None):
-      raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
-   elif (vlsvTObject is not None) and (files_list is not None):
-      raise ValueError("Please only provide one source of files")
-   if (seed_points is None):
-      raise ValueError("Please provide seed points")
-  
-   #number of time steps
-   if files_list is not None: 
-      vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
-   if integration_steps % points_per != 0:
-      raise ValueError("Number of integration steps must be divisible by the number of points recorded between timesteps")
+   def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
+      """
+      Streaklines 3D() integrates along dynamic field-grid vector field to calculate a final position. 
+      Code uses forward Euler method to conduct the tracing.
+      Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
+      i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
+      algorithm forward: 
+         -open file i
+         -place particle in i=j
+         -record all particle positions
+         -move all particles j<=i according to velocity at time i
+            -current_pos += velocity*dt
+         loop till end
+      keep track of current position using current_pos = (N,T*P,3)
+         
+         param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
+         param files_list:    List containing paths to VLSV files
+         param seed_points:   list of seed points for streaklines (meters)
+         param direction:     direction of integration (+,-, both)
+         param integration_steps:   number of integration steps between each timestep
+         param var:           integration variable
 
-   T = len(vlsvTObject.files)
-  
-   #number of seed points
-   N = len(seed_points)
-
-   T_eff = T*points_per-points_per+1
-   record_point = integration_steps//points_per
-
-   #helper functions
-   def active_indices(idx):
-      if direction =="+":
-         return range(0, idx+1)
-      return range(idx, T_eff)
+      returns: (N, T*P+1-P, T*P+1-P, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, and 3D coordinates
+      """
    
-   def inject_record(idx):
-      for n in range(N):
-         current_pos[n,idx, :] = seed_points[n]
-         M[n,idx, idx, :] = seed_points[n]
-      for n in range(N):
-         for j in active_indices(idx):
-            M[n, idx, j, :] = current_pos[n, j, :]
+      if (vlsvTObject is None) and (files_list is None):
+         raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
+      elif (vlsvTObject is not None) and (files_list is not None):
+         raise ValueError("Please only provide one source of files")
+      if (seed_points is None):
+         raise ValueError("Please provide seed points")
+   
+      #number of time steps
+      if files_list is not None: 
+         vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
-   if direction == "both":
+      if integration_steps % points_per != 0:
+         raise ValueError("Number of integration steps must be divisible by the number of points recorded between timesteps")
+
+      T = len(vlsvTObject.files)
+   
+      #number of seed points
+      N = len(seed_points)
+
+      T_eff = T*points_per-points_per+1
+      record_point = integration_steps//points_per
+
+      #helper functions
+      def active_indices(idx):
+         if direction =="+":
+            return range(0, idx+1)
+         return range(idx, T_eff)
       
-      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps, points_per = points_per, var = var)
-      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps, points_per = points_per, var = var)
-      M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
+      def inject_record(idx):
+         for n in range(N):
+            current_pos[n,idx, :] = seed_points[n]
+            M[n,idx, idx, :] = seed_points[n]
+         for n in range(N):
+            for j in active_indices(idx):
+               M[n, idx, j, :] = current_pos[n, j, :]
 
-      #fix diagonal
-      for t in range(T_eff):
-         M_both[:,t,t,:] = M_plus[:,t,t,:]
-      return M_both
-
-   #Full matrix to be filled with coordinates 
-   M = np.full((N, T_eff, T_eff, 3), np.nan)
-
-   sign = 1 if direction == "+" else -1
-   #records the current positions of the tracked plasma
-   current_pos = np.full((N, T_eff, 3), np.nan)
-
-   file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
-
-   for i, file_index in enumerate(file_indices):
-
-      eff_file_index = file_index*points_per
-
-      if i == 0:
-         #initial file read and timestep
-         t_0 = vlsvTObject.ts[file_index]
-
-      #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
-      inject_record(eff_file_index)
-
-      if i == T-1:
-         #On last step return the matrix and dont continue the integration
-         return M #matrix of form shape = (N, T, T, 3)
-
-      #INTEGRATION
-
-      #read next vlsvfile for time
-      next_file = file_index + 1 if direction == "+" else file_index - 1
-      
-      t_1 = vlsvTObject.ts[next_file]
-
-      #time between files
-      dt = abs(t_1-t_0)
-
-      #reads interpolated time between vlsvfiles
-      #dt*dt_step is integration step size 
-      dt_step = dt/integration_steps
-
-      #first record the current velocities 
-      
-      #indexing
-      js = np.array(list(active_indices(eff_file_index)))    
-      ns = np.arange(N)
-      n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
-      n_idx = n_idx.ravel()
-      j_idx = j_idx.ravel()
-
-      for step in range(integration_steps):
-
-         t_step = t_0 + dt_step*step*sign
-         positions = current_pos[n_idx, j_idx, :]
+      if direction == "both":
          
-         velocities = vlsvTObject(t_step, positions, var)
+         M_plus = streaklines.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps, points_per = points_per, var = var)
+         M_minus = streaklines.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps, points_per = points_per, var = var)
+         M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
+
+         #fix diagonal
+         for t in range(T_eff):
+            M_both[:,t,t,:] = M_plus[:,t,t,:]
+         return M_both
+
+      #Full matrix to be filled with coordinates 
+      M = np.full((N, T_eff, T_eff, 3), np.nan)
+
+      sign = 1 if direction == "+" else -1
+      #records the current positions of the tracked plasma
+      current_pos = np.full((N, T_eff, 3), np.nan)
+
+      file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
+
+      for i, file_index in enumerate(file_indices):
+
+         eff_file_index = file_index*points_per
+
+         if i == 0:
+            #initial file read and timestep
+            t_0 = vlsvTObject.ts[file_index]
+
+         #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
+         inject_record(eff_file_index)
+
+         if i == T-1:
+            #On last step return the matrix and dont continue the integration
+            return M #matrix of form shape = (N, T, T, 3)
+
+         #INTEGRATION
+
+         #read next vlsvfile for time
+         next_file = file_index + 1 if direction == "+" else file_index - 1
          
-         current_pos[n_idx, j_idx, :] += sign*velocities*dt_step
+         t_1 = vlsvTObject.ts[next_file]
 
-         if (step+1)% record_point == 0:
-            record_idx = (step+1)//record_point
-            
-            if record_idx == points_per:
-               #skip here since recorded at the beginning of the next loop
-               continue
-            
-            eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx   
-            
-            #adding seed points between timesteps 
-            inject_record(eff_idx)
+         #time between files
+         dt = abs(t_1-t_0)
 
-            #preps indeces for next loop
-            js = np.array(list(active_indices(eff_idx)))  
-            n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
-            n_idx = n_idx.ravel()
-            j_idx = j_idx.ravel()
-            
-      #set next points as current points for the next looping
-      t_0 = t_1
-      
-   #Back up return M 
-   return M #matrix of form shape = (N, T_eff, T_eff, 3)
+         #reads interpolated time between vlsvfiles
+         #dt*dt_step is integration step size 
+         dt_step = dt/integration_steps
 
+         #first record the current velocities 
+         
+         #indexing
+         js = np.array(list(active_indices(eff_file_index)))    
+         ns = np.arange(N)
+         n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
+         n_idx = n_idx.ravel()
+         j_idx = j_idx.ravel()
+
+         for step in range(integration_steps):
+
+            t_step = t_0 + dt_step*step*sign
+            positions = current_pos[n_idx, j_idx, :]
+            
+            velocities = vlsvTObject(t_step, positions, var)
+            
+            current_pos[n_idx, j_idx, :] += sign*velocities*dt_step
+
+            if (step+1)% record_point == 0:
+               record_idx = (step+1)//record_point
+               
+               if record_idx == points_per:
+                  #skip here since recorded at the beginning of the next loop
+                  continue
+               
+               eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx   
+
+               #adding seed points between timesteps 
+               inject_record(eff_idx)
+
+               #preps indeces for next loop
+               js = np.array(list(active_indices(eff_idx)))  
+               n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
+               n_idx = n_idx.ravel()
+               j_idx = j_idx.ravel()
+               
+         #set next points as current points for the next looping
+         t_0 = t_1
+         
+      #Back up return M 
+      return M #matrix of form shape = (N, T_eff, T_eff, 3)
+
+
+   def get_pathline(self):
+      pathline = np.array([])
+      return pathline
+   
+   def get_streakline(self):
+      streakline = np.array([])
+      return streakline

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -441,6 +441,9 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
    if files_list is not None: 
       vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
+   if integration_steps % points_per != 0:
+      raise ValueError("Number of integration steps must be divisible by the number of points recorded between timesteps")
+
    T = len(vlsvTObject.files)
   
    #number of seed points
@@ -449,13 +452,19 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
    T_eff = T*points_per-points_per+1
    record_point = integration_steps//points_per
 
-   #Also just prefill diagonal with seed points.
-   #No need to have it in the actual loops
-   #prepping functions for polishing code
-   def active_indices():
-      return
-   def inject_record():
-      return
+   #helper functions
+   def active_indices(idx):
+      if direction =="+":
+         return range(0, idx+1)
+      return range(idx, T_eff)
+   
+   def inject_record(idx):
+      for n in range(N):
+         current_pos[n,idx, :] = seed_points[n]
+         M[n,idx, idx, :] = seed_points[n]
+      for n in range(N):
+         for j in active_indices(idx):
+            M[n, idx, j, :] = current_pos[n, j, :]
 
    if direction == "both":
       
@@ -483,28 +492,10 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
 
       if i == 0:
          #initial file read and timestep
-         
-         vlsvfile  = vlsvTObject.readers[file_index]
          t_0 = vlsvTObject.ts[file_index]
 
       #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
-      #injecting points
-      for n in range(N):
-         current_pos[n, eff_file_index,:] = seed_points[n]
-         #Diagonal point so initial point
-         M[n, eff_file_index, eff_file_index,:] = seed_points[n]
-
-      if direction == "+":
-         current_cols = range(0, eff_file_index+1)
-      
-      elif direction == "-":
-         #negative direction
-         current_cols = range(eff_file_index, T_eff)
-      
-      #record current positions
-      for n in range(N):
-         for j in current_cols:
-            M[n,eff_file_index,j,:] = current_pos[n,j,:] 
+      inject_record(eff_file_index)
 
       if i == T-1:
          #On last step return the matrix and dont continue the integration
@@ -515,7 +506,6 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
       #read next vlsvfile for time
       next_file = file_index + 1 if direction == "+" else file_index - 1
       
-      next_vlsv = vlsvTObject.readers[next_file]
       t_1 = vlsvTObject.ts[next_file]
 
       #time between files
@@ -526,12 +516,9 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
       dt_step = dt/integration_steps
 
       #first record the current velocities 
-      if direction == "+":
-         js = np.arange(0, eff_file_index + 1)
-      else:
-         #negative direction
-         js = np.arange(eff_file_index, T_eff)
-          
+      
+      #indexing
+      js = np.array(list(active_indices(eff_file_index)))    
       ns = np.arange(N)
       n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
       n_idx = n_idx.ravel()
@@ -548,46 +535,25 @@ def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, di
 
          if (step+1)% record_point == 0:
             record_idx = (step+1)//record_point
-            eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx
-            print(t_step)
+            
             if record_idx == points_per:
                #skip here since recorded at the beginning of the next loop
-               #structure could be improved? 
                continue
-               
+            
+            eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx   
+            
             #adding seed points between timesteps 
-            for n in range(N):
-               current_pos[n,eff_idx,:] = seed_points[n]
-               M[n,eff_idx, eff_idx, :] = seed_points[n]
-            
-            if direction == "+":
-               js = np.arange(0,eff_idx+1)
+            inject_record(eff_idx)
 
-            elif direction == "-":
-               #negative direction
-               js = np.arange(eff_idx, T_eff)
-            
             #preps indeces for next loop
+            js = np.array(list(active_indices(eff_idx)))  
             n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
             n_idx = n_idx.ravel()
             j_idx = j_idx.ravel()
             
-            if direction == "+":
-               rec_cols = range(0, eff_idx+1)
-            elif direction == "-":
-               rec_cols = range(eff_idx, T_eff)
-            
-            #record current positions between timesteps 
-            for n in range(N):
-               for j in rec_cols:
-                  M[n,eff_idx,j,:] = current_pos[n,j,:] 
-
       #set next points as current points for the next looping
       t_0 = t_1
-      vlsvfile = next_vlsv 
       
-
-   
    #Back up return M 
-   return M #matrix of form shape = (N, T, T, 3)
+   return M #matrix of form shape = (N, T_eff, T_eff, 3)
 

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -447,6 +447,7 @@ class streaklines:
       self.var = var
       import math
       self.math = math
+      self.requested_vars = tracked_vars
       
       if files_list is not None: 
          #adding as readers since VlsvTInterpolator has no caching 
@@ -585,9 +586,9 @@ class streaklines:
          elif method == "RK4":
             #runge-kutta 4 integration method, see: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
             k1 = _get_var(t_step, positions)
-            k2 = _get_var(t_step + dt_s/2, positions + sign*k1*dt_s/2)
-            k3 = _get_var(t_step + dt_s/2, positions + sign*k2*dt_s/2)
-            k4 = _get_var(t_step + dt_s, positions + sign*dt_s*k3)
+            k2 = _get_var(t_step + sign*dt_s/2, positions + sign*k1*dt_s/2)
+            k3 = _get_var(t_step + sign*dt_s/2, positions + sign*k2*dt_s/2)
+            k4 = _get_var(t_step + sign*dt_s, positions + sign*dt_s*k3)
             v = 1/6*(k1 + 2*k2 + 2*k3 + k4)
          else:
             raise ValueError("not a valid integrations type")
@@ -608,8 +609,8 @@ class streaklines:
 
       if direction == "both":
          
-         M_plus, tracked_plus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", points_per = points_per, var = var, method=method, dt_step= dt_step,tracked_vars=tracked_vars)
-         M_minus, tracked_minus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", points_per = points_per, var = var,method=method, dt_step = dt_step, tracked_vars=tracked_vars)
+         M_plus, tracked_plus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", points_per = points_per, var = var, method=method, dt_step= dt_step,tracked_vars=self.requested_vars)
+         M_minus, tracked_minus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", points_per = points_per, var = var,method=method, dt_step = dt_step, tracked_vars=self.requested_vars)
          M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
          tracked_both = tracked_plus # TODO Implement tracked variables in both directions
          #fix diagonal

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -407,9 +407,9 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
    return points_traced       # list for fg; 3d numpy array(N,maxiterations,3) for vg
 
 
-def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= False, integration_steps = 1):
+def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, direction="+", integration_steps = 10, var = "vg_v"):
    """
-   form a (N, T, T, 3) matrix where N: number of seed points, T: number of timesteps, and 3D coordinates
+   forms a (N, T, T, 3) matrix where N: number of seed points, T: number of timesteps, and 3D coordinates
    Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
    i=j gives the seed point/release point where particles are started to track 
    algorithm forward: 
@@ -420,22 +420,43 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
          -current_pos += velocity*dt
       loop till end
    keep track of current position using current_pos = (N,T,3)
-   """
 
-   if direction == "both":
-      M_plus = streaklines_3D(files_list, seed_points, direction="+", is_test=is_test)
-      M_minus = streaklines_3D(files_list, seed_points, direction="-", is_test=is_test)
-      M_both =  np.nansum(np.stack([M_plus,M_minus], axis = 0),axis = 0)
-      #fix diagonal
-      for t in range(len(files_list)):
-         M_both[:,t,t,:] = M_plus[:,t,t,:]
-      return M_both
+      param files_list:    List containing paths to VLSV files
+      param seed_points:   list of seed points for streaklines (meters)
+      param direction:     direction of integration (+,-, both)
+      param integration_steps:   number of integration steps between each timestep
+      param var:           integration variable
+
+   """
+  
+   if (vlsvTObject is None) and (files_list is None):
+      raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
+   elif (vlsvTObject is not None) and (files_list is not None):
+      raise ValueError("Please only provide one source of files")
+   if (seed_points is None):
+      raise ValueError("Provide seed points for streaklines")
+  
    #number of time steps
-   T = len(files_list)
+   if files_list is not None: 
+      vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
+
+   T = len(vlsvTObject.files)
+  
    #number of seed points
    N = len(seed_points)
 
-   #Full matrix that is filled with coordinates 
+   if direction == "both":
+      
+      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps=integration_steps)
+      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps=integration_steps)
+      M_both =  np.nansum(np.stack([M_plus,M_minus], axis = 0), axis = 0)
+
+      #fix diagonal
+      for t in range(T):
+         M_both[:,t,t,:] = M_plus[:,t,t,:]
+      return M_both
+
+   #Full matrix to be filled with coordinates 
    M = np.full((N,T,T,3), np.nan)
 
    sign = 1 if direction == "+" else -1
@@ -448,14 +469,11 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
 
       if i == 0:
          #initial file read and timestep
-         if is_test:
-            print("test")
-            t_0 = 0
-         else:   
-            vlsvfile = pt.vlsvfile.VlsvReader(files_list[file_index])
-            t_0 = vlsvfile.read_parameter("time")
-      for n in range(N):
+         
+         vlsvfile  =vlsvTObject.readers[file_index]
+         t_0 = vlsvTObject.ts[file_index]
 
+      for n in range(N):
          current_pos[n, file_index,:] = seed_points[n]
          #Diagonal point so initial point
          M[n, file_index, file_index,:] = seed_points[n]
@@ -471,11 +489,13 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
       for n in range(N):
          for j in current_cols:
             M[n,file_index,j,:] = current_pos[n,j,:] 
+
       if i == T-1:
          #On last step return the matrix and dont continue the integration
-         return M
+         return M #matrix of form shape = (N, T, T, 3)
 
-      #INTEGRATION STARTS HERE
+      #INTEGRATION
+
       #first record the current velocities 
       if direction == "+":
          js = np.arange(0,file_index+1)
@@ -483,41 +503,44 @@ def streaklines_3D(files_list: list, seed_points: list, direction="+", is_test= 
          #negative direction
          js = np.arange(file_index,T)
          
-
       ns = np.arange(N)
-      n_idx, j_idx = np.meshgrid(ns,js, indexing = "ij")
+      n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
       n_idx = n_idx.ravel()
       j_idx = j_idx.ravel()
 
       #read next vlsvfile for time
       next_file = file_index + 1 if direction == "+" else file_index - 1
-      next_vslv = pt.vlsvfile.VlsvReader(files_list[next_file])
-      t_1 = next_vslv.read_parameter("time")
       
+      next_vlsv = vlsvTObject.readers[next_file]
+      t_1 = vlsvTObject.ts[next_file]
+
       dt = abs(t_1-t_0)
 
       if integration_steps == 1:
 
+         #possibly (most likely) unnecessary and does the same as the else case if integration steps is 1
+         #should be deleted
          positions = current_pos[n_idx,j_idx, :]
-
-         velocities = vlsvfile.read_interpolated_variable("vg_v",positions)
-
+         velocities = vlsvfile.read_interpolated_variable(var, positions)
          #calculate new positions 
          current_pos[n_idx, j_idx, :] += sign*velocities*dt
+
       else: 
-         #reads interpolated time between vlsvfiles for more accurate integration
+         #reads interpolated time between vlsvfiles
          dt_step = dt/integration_steps
 
          for step in range(integration_steps):
 
-            t_step = t_0 + dt_step*step
+            t_step = t_0 + dt_step*step*sign
             positions = current_pos[n_idx,j_idx, :]
-            velocities = pt.calculations.timeevolution.get_interpolated_variable(vlsvfile,next_vslv, "vg_v", positions,t_step)
+            
+            velocities = vlsvTObject(t_step, positions, var)
+            
             current_pos[n_idx,j_idx, :] += sign*velocities*dt_step
 
       #set next points as current points for the next looping
       t_0 = t_1
-      vlsvfile = next_vslv 
+      vlsvfile = next_vlsv 
       
 
    

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -411,26 +411,66 @@ class streaklines:
    """
    Class to analyze temporal pathlines and streaklines between a range of Vlasiator time steps
 
-   Use: 
+   Example Use to create plot showing pathline of an released particle 
+   and the streakline of the fluid over the entire time period: 
+
    seed = [1e8, 0, 0]
    files_list = ["./bulk1.0001300.vlsv","./bulk1.00013005.vlsv"]
    streakline_object = pt.calculations.streaklines(files_list = files_list, seed_points = seed)
    #extract pathline
    pathline = streakline_object.get_pathline(seed_idx = 0, time = 1303)
+   #extracting full matrix
+   M = streakline_object.M
+   #extract pathline of particle released at 1303 and plotting x-y plane of path
+   pathline = streakline_object.get_pathline(seed_idx = 0, time = 1300)
+   plt.plot(pathline[:,0], pathline[:,1], linestyle = "--")
+   streakline = streakline_object.get_streakline(seed_idx = 0, time = 1305, label= "streakline")
+   plt.plot(streakline[:,0], streakline[:,1])
+   
    """
 
-   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler"):
+   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler"):
+      """
+      Initiation of class 
+      param vlsvTObject:   A callable object that can be used to interpolate values in time and space from the given files
+      param files_list:    List containing paths to VLSV files
+      param seed_points:   list of seed points for streaklines (meters)
+      param direction:     direction of integration (+,-, both)
+      param dt_step:       time step size of integration 
+      param var:           integration variable
+      param method:        integration step method (euler, RK4)
+      param point_recorded:Number of total recorded points
+      param points_per:    Alternative to points_recorded. Number of points recorded per time step
+      """
 
+      self.dt_step = dt_step
+      self.method = method
+      self.seed_points = seed_points
+      self.var = var
+      import math
+      self.math = math
+      
       if files_list is not None: 
          #adding as readers since VlsvTInterpolator has no caching 
          readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
          vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
 
-      self.M = self.streaklines_3D(vlsvTObject=vlsvTObject, 
-                                   seed_points=seed_points, direction=direction,points_per=points_per,
-                                   dt_step = dt_step,var = var, method = method)
+      #Defining the amount of point recorded per timestep as the total wanted recorded points 
+      #divided by the amount of time steps
+      if points_recorded is not None:
+         self.points_per = int(self.math.ceil(points_recorded/len(vlsvTObject.ts)))
+      else:
+         self.points_per = points_per
+      
+      #initial sanity check to make sure integration steps > points recorded per time step:
+      if self.points_per > self.math.ceil(abs(vlsvTObject.ts[1]-vlsvTObject.ts[0])/dt_step):
+         raise ValueError("Trying to record more points than there are integration steps. Consider lowering recorded points or decreasing dt_step")
       
       self.time_range = [min(vlsvTObject.ts), max(vlsvTObject.ts)]
+      self.M = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, 
+                                   direction = direction, points_per = self.points_per,
+                                   dt_step = dt_step, var = var, method = method)
+      
 
       pass
 
@@ -506,7 +546,7 @@ class streaklines:
 
       #function trivialize change of integration method
       def integration_step(t_step, dt_s, n_idx, j_idx, method = method):
-         #dp is the displacement amount in a integration step
+         #dt_s*v is the displacement amount in a integration step
          """
          pram t_step: time step is taken
          pram dt_s:   size of the integration step
@@ -519,19 +559,29 @@ class streaklines:
 
          if method == "euler":
             #classic euler step method of integration
-            dx =  _get_var(t_step, positions)
+            v =  _get_var(t_step, positions)
          elif method == "RK4":
             #runge-kutta 4 integration method, see: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
             k1 = _get_var(t_step, positions)
             k2 = _get_var(t_step + dt_s/2, positions + sign*k1*dt_s/2)
             k3 = _get_var(t_step + dt_s/2, positions + sign*k2*dt_s/2)
             k4 = _get_var(t_step + dt_s, positions + sign*dt_s*k3)
-            dx = 1/6*(k1 + 2*k2 + 2*k3 + k4)
+            v = 1/6*(k1 + 2*k2 + 2*k3 + k4)
          else:
             raise ValueError("not a valid integrations type")
          
          #update current particle positions according to the step
-         current_pos[n_idx, j_idx, :] += sign*dt_s*dx
+         v = v.reshape(-1,3)
+         """
+         if np.any(np.linalg.norm(dt_s*v,axis=1)>max_dx):
+            #recursively add additional two half sized integration steps 
+            integration_step(t_step, dt_s/2, n_idx, j_idx, method=method)
+            integration_step(t_step+sign*dt_s/2, dt_s/2, n_idx, j_idx, method = method)
+            
+            return
+         """
+         #print(np.max(np.linalg.norm(dt_s*v,axis=1)))
+         current_pos[n_idx, j_idx, :] += sign*dt_s*v
 
 
       if direction == "both":
@@ -667,10 +717,166 @@ class streaklines:
    def get_streakline(self, seed_idx, time):
       """
       Get the streakline between the start time and a given time
-   
       time input --> return closest streakline 
       """
       time_idx = self._time_to_idx(time=time)
       streakline = self.M[seed_idx, time_idx, :, : ]
 
       return streakline 
+
+
+def pathlines(vlsvTObject = None, files_list = None, seed_points = None, direction = "+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", tracked_vars = None, method = "euler"):
+   """
+   Function to track the pathlines of plasma parcels and their features ("vg_b_vol", "proton/vg_beta_star" etc.)
+   Scales better than streaklines class if pathlines are of only interest.
+   Example use:
+   seed = [1e8, 0, 0]
+   files_list = ["./bulk1.0001300.vlsv","./bulk1.00013005.vlsv"]
+   pathslines, tracked_vars = pt.calculations.fieldtracer.pathlines(files_list = files_list, seed_points = seed,
+                                                                   tracked_vars = ["vg_b_vol", "proton/vg_beta_star"])
+   magnetic_field_data = tracked_vars["vg_b_vol"]
+   --> cool plots
+   """ 
+   import math
+
+   if (vlsvTObject is None) and (files_list is None):
+         raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
+   elif (vlsvTObject is not None) and (files_list is not None):
+      raise ValueError("Please only provide one source of files")
+   if (seed_points is None):
+      raise ValueError("Please provide seed points")
+
+   if files_list is not None: 
+      #adding as readers since VlsvTInterpolator has no caching 
+      readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
+      vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
+
+   #Defining the amount of point recorded per timestep as the total wanted recorded points 
+   #divided by the amount of time steps
+   if points_recorded is not None:
+      points_per = int(math.ceil(points_recorded/len(vlsvTObject.ts)))
+   else:
+      points_per = points_per
+   
+   #initial sanity check to make sure integration steps > points recorded per time step:
+   if points_per > math.ceil(abs(vlsvTObject.ts[1]-vlsvTObject.ts[0])/dt_step):
+      raise ValueError("Trying to record more points than there are integration steps. Consider lowering recorded points or decreasing dt_step")
+   
+   #number of time steps
+   T = len(vlsvTObject.files)
+   #number of seed points
+   N = len(seed_points)
+   #effective number of time steps due to inbetween recordings
+   T_eff = T*points_per-points_per+1
+
+   pathline_obj = np.full((N, T_eff, 3), np.nan)
+   
+   
+   #records the current positions of the tracked plasma
+   current_pos = np.array(seed_points,dtype = float)
+
+   tracked_objs = {}
+   if tracked_vars is not None:
+      for tracked_var in tracked_vars:
+         test_val = np.array(vlsvTObject(vlsvTObject.ts[0], current_pos, tracked_var))
+         if test_val.ndim == 0:
+            test_val = test_val.reshape(1)
+         if test_val.shape[0] !=N:
+            test_val = test_val.reshape(N,-1)
+         var_shape = test_val.shape[1:]
+         tracked_objs[tracked_var] = np.full((N,T_eff) + var_shape, np.nan)
+         print(tracked_objs[tracked_var].shape)
+         
+   def _get_var(t, positions, var):
+      result = vlsvTObject(t, positions, var)
+      if result.ndim == 0:
+         result = result.reshape(1)
+      if result.shape[0] !=N:
+         result = result.reshape(N,-1)
+      return result
+
+   def integration_step(t_step, dt_s, current_pos,  method = method):
+         #dt_s*v is the displacement amount in a integration step
+         """
+         pram t_step: time step is taken
+         pram dt_s:   size of the integration step
+         pram n_idx:  seed point index array
+         pram j_idx:  release time index array
+
+         """
+
+         positions = current_pos
+
+         if method == "euler":
+            #classic euler step method of integration
+            v =  _get_var(t_step, positions,var)
+         elif method == "RK4":
+            #runge-kutta 4 integration method, see: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
+            k1 = _get_var(t_step, positions, var)
+            k2 = _get_var(t_step + dt_s/2, positions + sign*k1*dt_s/2, var)
+            k3 = _get_var(t_step + dt_s/2, positions + sign*k2*dt_s/2, var)
+            k4 = _get_var(t_step + dt_s, positions + sign*dt_s*k3, var)
+            v = 1/6*(k1 + 2*k2 + 2*k3 + k4)
+         else:
+            raise ValueError("not a valid integrations type")
+         
+         #update current particle positions according to the step
+         v = v.reshape(-1,3)
+         """
+         if np.any(np.linalg.norm(dt_s*v,axis=1)>max_dx):
+            #recursively add additional two half sized integration steps 
+            integration_step(t_step, dt_s/2, n_idx, j_idx, method=method)
+            integration_step(t_step+sign*dt_s/2, dt_s/2, n_idx, j_idx, method = method)
+            
+            return
+         """
+         #print(np.max(np.linalg.norm(dt_s*v,axis=1)))
+         current_pos += sign*dt_s*v
+   
+   sign = 1 if direction == "+" else -1
+
+   file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
+
+   #MAIN LOOP
+   for i, file_index in enumerate(file_indices):
+
+      eff_file_index = file_index*points_per
+
+      t_0 = vlsvTObject.ts[file_index]
+
+      pathline_obj[:,eff_file_index,:] = current_pos
+      if tracked_vars is not None:
+         for tracked_var in tracked_vars:
+            tracked_objs[tracked_var][:,eff_file_index] = _get_var(t_0, current_pos, tracked_var)
+
+      if i == T-1:
+         break
+
+      next_file = file_index +1 if direction == "+" else file_index-1
+      t_1 = vlsvTObject.ts[next_file]
+      dt = abs(t_1-t_0)
+      
+      steps  = math.ceil(dt/dt_step)
+      t_elapsed = 0.0
+      prev_record_idx = 0
+
+      for step in range(steps):
+
+         t_step = t_0 + t_elapsed*sign
+         actual_dt = min(dt_step, dt-t_elapsed)
+
+         integration_step(t_step, actual_dt, current_pos, method = method)
+
+         t_elapsed += actual_dt
+
+         record_idx = int((t_elapsed)/dt*points_per)
+         if record_idx != prev_record_idx and record_idx < points_per:
+         
+               prev_record_idx = record_idx
+               eff_idx = eff_file_index + record_idx*sign  
+               pathline_obj[:,eff_idx,:] = current_pos
+               if tracked_vars is not None:
+                  for tracked_var in tracked_vars:
+                     tracked_objs[tracked_var][:,eff_idx] = _get_var(t_0+t_elapsed, current_pos, tracked_var)
+               
+   return pathline_obj, tracked_objs

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -439,7 +439,7 @@ class streaklines:
    
    """
 
-   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler"):
+   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_recorded = None, points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler", tracked_vars = None):
 
       self.dt_step = dt_step
       self.method = method
@@ -465,15 +465,15 @@ class streaklines:
          raise ValueError("Trying to record more points than there are integration steps. Consider lowering recorded points or decreasing dt_step")
       
       self.time_range = [min(vlsvTObject.ts), max(vlsvTObject.ts)]
-      self.M = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, 
+      self.M, self.tracked_objs = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, 
                                    direction = direction, points_per = self.points_per,
-                                   dt_step = dt_step, var = var, method = method)
+                                   dt_step = dt_step, var = var, method = method, tracked_vars=tracked_vars)
       
 
       pass
 
    
-   def streaklines_3D(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", dt_step=0.1, max_dx = 1e5, method = "euler", points_per = 10, var = "vg_v"):
+   def streaklines_3D(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", dt_step=0.1, max_dx = 1e5, method = "euler", points_per = 10, var = "vg_v", tracked_vars = None):
       """
       Streaklines 3D() integrates along dynamic field-grid vector field to calculate a final position. 
       Code uses Euler or RK4  method to conduct the tracing.
@@ -513,6 +513,24 @@ class streaklines:
       #effective number of time steps due to inbetween recordings
       T_eff = T*points_per-points_per+1
 
+      #Tracked variables
+      tracked_objs = {}
+      tracked_objs["Time"] = np.full((T_eff),np.nan)
+      if tracked_vars is not None:
+         for tracked_var in tracked_vars:
+            test_val = np.array(vlsvTObject(vlsvTObject.ts[0], seed_points, tracked_var))
+            if test_val.ndim == 0:
+               test_val = test_val.reshape(1)
+            if test_val.shape[0] !=N:
+               test_val = test_val.reshape(N,-1)
+            var_shape = test_val.shape[1:]
+            tracked_objs[tracked_var] = np.full((N,T_eff, T_eff) + var_shape, np.nan)
+         tracked_vars  = list(tracked_vars) + ["Time"]
+      else:
+         tracked_vars = ["Time"]
+      
+      logging.info(f"Tracked variables: {tracked_vars}")
+
       #helper functions
       def active_indices(idx):
          if direction =="+":
@@ -528,10 +546,27 @@ class streaklines:
             for j in js:
                M[n, i_idx, j, :] = current_pos[n, j, :]
 
-      def _get_var(t, positions):
-         return vlsvTObject(t, positions, var)
+      def record_tracked(i_idx, js, t):
+         for tracked_var in tracked_vars:
+            if tracked_var == "Time":
+               tracked_objs["Time"][i_idx] = t
+            else:
+               for j in js:
+                  positions = current_pos[:,j,:]
+                  vals = _get_var(t, positions, tracked_var)
+                  tracked_objs[tracked_var][:,i_idx, j] = vals
+               
+      #if no variable explicitally set uses the streaklines class var
+      def _get_var(t, positions, var = var):
+         result = vlsvTObject(t, positions, var)
+         n_pos = len(positions)
+         if result.ndim == 0:
+            result = result.reshape(1)
+         if result.shape[0] !=n_pos:
+            result = result.reshape(n_pos,-1)
+         return result
 
-      #function trivialize change of integration method
+      #function to ease change of integration method
       def integration_step(t_step, dt_s, n_idx, j_idx, method = method):
          #dt_s*v is the displacement amount in a integration step
          """
@@ -573,14 +608,14 @@ class streaklines:
 
       if direction == "both":
          
-         M_plus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", points_per = points_per, var = var, method=method, dt_step= dt_step)
-         M_minus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", points_per = points_per, var = var,method=method, dt_step = dt_step)
+         M_plus, tracked_plus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", points_per = points_per, var = var, method=method, dt_step= dt_step,tracked_vars=tracked_vars)
+         M_minus, tracked_minus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", points_per = points_per, var = var,method=method, dt_step = dt_step, tracked_vars=tracked_vars)
          M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
-
+         tracked_both = tracked_plus # TODO Implement tracked variables in both directions
          #fix diagonal
          for t in range(T_eff):
             M_both[:,t,t,:] = M_plus[:,t,t,:]
-         return M_both
+         return M_both, tracked_both
 
       #Full matrix to be filled with coordinates 
       M = np.full((N, T_eff, T_eff, 3), np.nan)
@@ -600,15 +635,17 @@ class streaklines:
          if i == 0:
             #initial file read and timestep
             t_0 = vlsvTObject.ts[file_index]
-
+         
+         logging.info(f"Current timestep: {t_0}")
          #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
          inject_particles(eff_file_index)
          js = np.array(list(active_indices(eff_file_index)))
          record_particles(eff_file_index,js)
+         record_tracked(eff_file_index, js, t_0)
 
          if i == T-1:
             #On last step return the matrix and dont continue the integration
-            return M #matrix of form shape = (N, T, T, 3)
+            return M, tracked_objs #matrix of form shape = (N, T, T, 3)
 
          #INTEGRATION
 
@@ -648,7 +685,6 @@ class streaklines:
             
             #integration step
             integration_step(t_step, actual_dt, n_idx, j_idx)
-            
             #keeping track of the elapsed time
             t_elapsed += actual_dt
 
@@ -666,7 +702,7 @@ class streaklines:
                inject_particles(eff_idx)
                js = np.array(list(active_indices(eff_idx)))
                record_particles(eff_idx, js)
-
+               record_tracked(eff_idx,js, t_0 + t_elapsed*sign)
                #preps indeces for next loop  
                n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
                n_idx = n_idx.ravel()
@@ -677,7 +713,7 @@ class streaklines:
          
       #Back up return M 
       
-      return M #matrix of form shape = (N, T_eff, T_eff, 3)
+      return M, tracked_objs #matrix of form shape = (N, T_eff, T_eff, 3) and dictonary of tracked object matrices
 
    def _time_to_idx(self, time):
       """

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -434,7 +434,7 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
    elif (vlsvTObject is not None) and (files_list is not None):
       raise ValueError("Please only provide one source of files")
    if (seed_points is None):
-      raise ValueError("Provide seed points for streaklines")
+      raise ValueError("Please provide seed points")
   
    #number of time steps
    if files_list is not None: 
@@ -447,9 +447,9 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
 
    if direction == "both":
       
-      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps=integration_steps)
-      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps=integration_steps)
-      M_both =  np.nansum(np.stack([M_plus,M_minus], axis = 0), axis = 0)
+      M_plus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps)
+      M_minus = streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps)
+      M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
 
       #fix diagonal
       for t in range(T):
@@ -457,11 +457,11 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       return M_both
 
    #Full matrix to be filled with coordinates 
-   M = np.full((N,T,T,3), np.nan)
+   M = np.full((N, T, T, 3), np.nan)
 
    sign = 1 if direction == "+" else -1
    #records the current positions of the tracked plasma
-   current_pos = np.full((N,T,3), np.nan)
+   current_pos = np.full((N, T, 3), np.nan)
 
    file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
 
@@ -470,7 +470,7 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       if i == 0:
          #initial file read and timestep
          
-         vlsvfile  =vlsvTObject.readers[file_index]
+         vlsvfile  = vlsvTObject.readers[file_index]
          t_0 = vlsvTObject.ts[file_index]
 
       for n in range(N):
@@ -479,11 +479,11 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
          M[n, file_index, file_index,:] = seed_points[n]
       
       if direction == "+":
-         current_cols = range(0,file_index+1)
+         current_cols = range(0, file_index+1)
       
       elif direction == "-":
          #negative direction
-         current_cols = range(file_index,T)
+         current_cols = range(file_index, T)
       
       #record current positions
       for n in range(N):
@@ -498,10 +498,10 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
 
       #first record the current velocities 
       if direction == "+":
-         js = np.arange(0,file_index+1)
+         js = np.arange(0, file_index + 1)
       else:
          #negative direction
-         js = np.arange(file_index,T)
+         js = np.arange(file_index, T)
          
       ns = np.arange(N)
       n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
@@ -514,29 +514,21 @@ def streaklines_3D(vlsvTObject= None, files_list = None, seed_points = None, dir
       next_vlsv = vlsvTObject.readers[next_file]
       t_1 = vlsvTObject.ts[next_file]
 
+      #time between files
       dt = abs(t_1-t_0)
 
-      if integration_steps == 1:
+      #reads interpolated time between vlsvfiles
+      #dt*dt_step is integration step size 
+      dt_step = dt/integration_steps
 
-         #possibly (most likely) unnecessary and does the same as the else case if integration steps is 1
-         #should be deleted
-         positions = current_pos[n_idx,j_idx, :]
-         velocities = vlsvfile.read_interpolated_variable(var, positions)
-         #calculate new positions 
-         current_pos[n_idx, j_idx, :] += sign*velocities*dt
+      for step in range(integration_steps):
 
-      else: 
-         #reads interpolated time between vlsvfiles
-         dt_step = dt/integration_steps
-
-         for step in range(integration_steps):
-
-            t_step = t_0 + dt_step*step*sign
-            positions = current_pos[n_idx,j_idx, :]
-            
-            velocities = vlsvTObject(t_step, positions, var)
-            
-            current_pos[n_idx,j_idx, :] += sign*velocities*dt_step
+         t_step = t_0 + dt_step*step*sign
+         positions = current_pos[n_idx, j_idx, :]
+         
+         velocities = vlsvTObject(t_step, positions, var)
+         
+         current_pos[n_idx, j_idx, :] += sign*velocities*dt_step
 
       #set next points as current points for the next looping
       t_0 = t_1

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -419,27 +419,26 @@ class streaklines:
    pathline = streakline_object.get_pathline(seed_idx = 0, time = 1303)
    """
 
-   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
+   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, dt_step = 0.1, var = "vg_v", method = "euler"):
 
       if files_list is not None: 
          #adding as readers since VlsvTInterpolator has no caching 
          readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
          vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
 
-
       self.M = self.streaklines_3D(vlsvTObject=vlsvTObject, 
                                    seed_points=seed_points, direction=direction,points_per=points_per,
-                                   integration_steps=integration_steps,var = var)
+                                   dt_step = dt_step,var = var, method = method)
       
       self.time_range = [min(vlsvTObject.ts), max(vlsvTObject.ts)]
 
       pass
 
    
-   def streaklines_3D(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
+   def streaklines_3D(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", dt_step=0.1, max_dx = 1e5, method = "euler", points_per = 10, var = "vg_v"):
       """
       Streaklines 3D() integrates along dynamic field-grid vector field to calculate a final position. 
-      Code uses forward Euler method to conduct the tracing.
+      Code uses Euler or RK4  method to conduct the tracing.
       Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles
       i=j gives the seed point/release point where particles are started to track. For consistent logic keep integrations steps divisible by points_per
       algorithm forward: 
@@ -455,12 +454,17 @@ class streaklines:
          param files_list:    List containing paths to VLSV files
          param seed_points:   list of seed points for streaklines (meters)
          param direction:     direction of integration (+,-, both)
-         param integration_steps:   number of integration steps between each timestep
+         param dt_step:       time step size of integration 
          param var:           integration variable
+         param method:        integration step method (euler, RK4)
+         param points_per     number of points recorded between time steps
 
       returns: (N, T*P+1-P, T*P+1-P, 3) matrix where N: number of seed points, T: number of timesteps, P: points per timestep, and 3D coordinates
       """
-   
+
+      import math
+
+      #Initial input checks
       if (vlsvTObject is None) and (files_list is None):
          raise ValueError("Provide either a VlsvTInterpolator object or a list of vlsv file paths")
       elif (vlsvTObject is not None) and (files_list is not None):
@@ -468,24 +472,19 @@ class streaklines:
       if (seed_points is None):
          raise ValueError("Please provide seed points")
    
-     
+
       if files_list is not None: 
          #adding as readers since VlsvTInterpolator has no caching 
          readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
          vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
          #vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
-      if integration_steps % points_per != 0:
-         raise ValueError("Number of integration steps must be divisible by the number of points recorded between timesteps")
-
       #number of time steps
       T = len(vlsvTObject.files)
-   
       #number of seed points
       N = len(seed_points)
-
+      #effective number of time steps due to inbetween recordings
       T_eff = T*points_per-points_per+1
-      record_point = integration_steps//points_per
 
       #helper functions
       def active_indices(idx):
@@ -493,18 +492,52 @@ class streaklines:
             return range(0, idx+1)
          return range(idx, T_eff)
       
-      def inject_record(idx):
-         for n in range(N):
+      def inject_particles(idx):
+          for n in range(N):
             current_pos[n,idx, :] = seed_points[n]
-            M[n,idx, idx, :] = seed_points[n]
+        
+      def record_particles(i_idx, js):
          for n in range(N):
-            for j in active_indices(idx):
-               M[n, idx, j, :] = current_pos[n, j, :]
+            for j in js:
+               M[n, i_idx, j, :] = current_pos[n, j, :]
+
+      def _get_var(t, positions):
+         return vlsvTObject(t, positions, var)
+
+      #function trivialize change of integration method
+      def integration_step(t_step, dt_s, n_idx, j_idx, method = method):
+         #dp is the displacement amount in a integration step
+         """
+         pram t_step: time step is taken
+         pram dt_s:   size of the integration step
+         pram n_idx:  seed point index array
+         pram j_idx:  release time index array
+
+         """
+
+         positions = current_pos[n_idx, j_idx]
+
+         if method == "euler":
+            #classic euler step method of integration
+            dx =  _get_var(t_step, positions)
+         elif method == "RK4":
+            #runge-kutta 4 integration method, see: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods
+            k1 = _get_var(t_step, positions)
+            k2 = _get_var(t_step + dt_s/2, positions + sign*k1*dt_s/2)
+            k3 = _get_var(t_step + dt_s/2, positions + sign*k2*dt_s/2)
+            k4 = _get_var(t_step + dt_s, positions + sign*dt_s*k3)
+            dx = 1/6*(k1 + 2*k2 + 2*k3 + k4)
+         else:
+            raise ValueError("not a valid integrations type")
+         
+         #update current particle positions according to the step
+         current_pos[n_idx, j_idx, :] += sign*dt_s*dx
+
 
       if direction == "both":
          
-         M_plus = streaklines.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", integration_steps = integration_steps, points_per = points_per, var = var)
-         M_minus = streaklines.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", integration_steps = integration_steps, points_per = points_per, var = var)
+         M_plus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "+", points_per = points_per, var = var, method=method, dt_step= dt_step)
+         M_minus = self.streaklines_3D(vlsvTObject = vlsvTObject, seed_points = seed_points, direction = "-", points_per = points_per, var = var,method=method, dt_step = dt_step)
          M_both =  np.nansum(np.stack([M_plus, M_minus], axis = 0), axis = 0)
 
          #fix diagonal
@@ -514,13 +547,15 @@ class streaklines:
 
       #Full matrix to be filled with coordinates 
       M = np.full((N, T_eff, T_eff, 3), np.nan)
-
-      sign = 1 if direction == "+" else -1
       #records the current positions of the tracked plasma
       current_pos = np.full((N, T_eff, 3), np.nan)
 
+      #sign keeps track of integration direction
+      sign = 1 if direction == "+" else -1
+
       file_indices = list(range(T)) if direction == "+" else list(range(T - 1, -1, -1))
 
+      #MAIN LOOP
       for i, file_index in enumerate(file_indices):
 
          eff_file_index = file_index*points_per
@@ -530,7 +565,9 @@ class streaklines:
             t_0 = vlsvTObject.ts[file_index]
 
          #INJECTING ON DIAGONAL POINTS AT TIMESTEPS 
-         inject_record(eff_file_index)
+         inject_particles(eff_file_index)
+         js = np.array(list(active_indices(eff_file_index)))
+         record_particles(eff_file_index,js)
 
          if i == T-1:
             #On last step return the matrix and dont continue the integration
@@ -540,48 +577,60 @@ class streaklines:
 
          #read next vlsvfile for time
          next_file = file_index + 1 if direction == "+" else file_index - 1
-         
          t_1 = vlsvTObject.ts[next_file]
 
          #time between files
          dt = abs(t_1-t_0)
-
-         #reads interpolated time between vlsvfiles
-         #dt*dt_step is integration step size 
-         dt_step = dt/integration_steps
-
-         #first record the current velocities 
          
          #indexing
-         js = np.array(list(active_indices(eff_file_index)))    
          ns = np.arange(N)
          n_idx, j_idx = np.meshgrid(ns,js,indexing = "ij")
          n_idx = n_idx.ravel()
          j_idx = j_idx.ravel()
+         
+         """
+         How integration step size is determined 
+         bulk_n        dt        bulk_n+1
+         |----------------------------|
+          dt_step dt_step dt_step (dt-t_elapsed)
+         |-------|-------|-------|----|
+         """
+         #number of integration steps
+         steps = math.ceil(dt/dt_step) 
+         t_elapsed = 0.0
+         prev_record_idx = 0
 
-         for step in range(integration_steps):
-
-            t_step = t_0 + dt_step*step*sign
-            positions = current_pos[n_idx, j_idx, :]
+         #integration loop
+         for step in range(steps):
             
-            velocities = vlsvTObject(t_step, positions, var)
+            #t_0: current file time, t_elapsed*sign: elapsed time toward next file
+            t_step = t_0 + t_elapsed*sign
             
-            current_pos[n_idx, j_idx, :] += sign*velocities*dt_step
+            #determining dt_step size
+            actual_dt = min(dt_step, dt-t_elapsed)
+            
+            #integration step
+            integration_step(t_step, actual_dt, n_idx, j_idx)
+            
+            #keeping track of the elapsed time
+            t_elapsed += actual_dt
 
-            if (step+1)% record_point == 0:
-               record_idx = (step+1)//record_point
-               
-               if record_idx == points_per:
-                  #skip here since recorded at the beginning of the next loop
-                  continue
-               
-               eff_idx = eff_file_index + record_idx if direction == "+" else eff_file_index - record_idx   
+            #this leaves nans if points_per too big and dt_step is too big relative to dt
+            record_idx = int((t_elapsed)/dt*points_per)
+           
+            #checking when to record particles
+            if record_idx != prev_record_idx and record_idx < points_per:
+         
+               prev_record_idx = record_idx
+
+               eff_idx = eff_file_index + record_idx*sign  
 
                #adding seed points between timesteps 
-               inject_record(eff_idx)
+               inject_particles(eff_idx)
+               js = np.array(list(active_indices(eff_idx)))
+               record_particles(eff_idx, js)
 
-               #preps indeces for next loop
-               js = np.array(list(active_indices(eff_idx)))  
+               #preps indeces for next loop  
                n_idx, j_idx = np.meshgrid(ns,js, indexing="ij")
                n_idx = n_idx.ravel()
                j_idx = j_idx.ravel()
@@ -593,40 +642,35 @@ class streaklines:
       
       return M #matrix of form shape = (N, T_eff, T_eff, 3)
 
-
    def _time_to_idx(self, time):
       """
-      From know dt, t range, and record_dt can determine 
+      From know dt, t range, and points_per can determine 
       for a given time the index in M  
       """
       if (time < self.time_range[0]) or (time> self.time_range[1]):
          raise ValueError(f"Time not with the analyzed time range of {self.time_range[0]}-{self.time_range[1]}")
-      idx = None
+      T_eff = self.M.shape[1]
+      frac = (time-self.time_range[0])/(self.time_range[1]-self.time_range[0])
+      idx = int(round(frac*(T_eff-1)))
       return idx
 
    def get_pathline(self, seed_idx, time):
       """
-      Get the pathline of a seed point released at a given time (release idx)
-      TODO currently this assumes that you know the index of a random time
-      --> make time be a input --> return closest pathline  
+      Get the pathline of a seed point released at a given time
+      time input --> return closest pathline  
       """
       release_idx = self._time_to_idx(time=time)
-      
       pathline = self.M[seed_idx, :, release_idx, :]
       
       return pathline
    
    def get_streakline(self, seed_idx, time):
       """
-      Get the streakline between the start time and a given time (time_idx)
-      TODO currently this assumes that you know the index of a random time
-      --> make time be a input --> return closest streakline 
-      the last time is interesting so letting -1 be option
+      Get the streakline between the start time and a given time
+   
+      time input --> return closest streakline 
       """
-      if time == -1:
-         time_idx = -1
-      else:
-         time_idx = self._time_to_idx(time=time)
+      time_idx = self._time_to_idx(time=time)
       streakline = self.M[seed_idx, time_idx, :, : ]
 
       return streakline 

--- a/analysator/calculations/fieldtracer.py
+++ b/analysator/calculations/fieldtracer.py
@@ -408,13 +408,35 @@ def static_field_tracer_3d( vlsvReader, seed_coords, max_iterations, dx, directi
 
 
 class streaklines: 
+   """
+   Class to analyze temporal pathlines and streaklines between a range of Vlasiator time steps
 
-   def __init__(self):
-      self.M = "matrix here"
+   Use: 
+   seed = [1e8, 0, 0]
+   files_list = ["./bulk1.0001300.vlsv","./bulk1.00013005.vlsv"]
+   streakline_object = pt.calculations.streaklines(files_list = files_list, seed_points = seed)
+   #extract pathline
+   pathline = streakline_object.get_pathline(seed_idx = 0, time = 1303)
+   """
+
+   def __init__(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
+
+      if files_list is not None: 
+         #adding as readers since VlsvTInterpolator has no caching 
+         readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
+         vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
+
+
+      self.M = self.streaklines_3D(vlsvTObject=vlsvTObject, 
+                                   seed_points=seed_points, direction=direction,points_per=points_per,
+                                   integration_steps=integration_steps,var = var)
+      
+      self.time_range = [min(vlsvTObject.ts), max(vlsvTObject.ts)]
+
       pass
 
-
-   def streaklines_3D(vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
+   
+   def streaklines_3D(self, vlsvTObject = None, files_list = None, seed_points = None, direction="+", points_per = 10, integration_steps = 10, var = "vg_v"):
       """
       Streaklines 3D() integrates along dynamic field-grid vector field to calculate a final position. 
       Code uses forward Euler method to conduct the tracing.
@@ -446,13 +468,17 @@ class streaklines:
       if (seed_points is None):
          raise ValueError("Please provide seed points")
    
-      #number of time steps
+     
       if files_list is not None: 
-         vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
+         #adding as readers since VlsvTInterpolator has no caching 
+         readers = [pt.vlsvfile.VlsvReader(f, indexer = "dict") for f in files_list]
+         vlsvTObject = pt.calculations.VlsvTInterpolator(vlsvReaders_list = readers)
+         #vlsvTObject = pt.calculations.VlsvTInterpolator(files_list)
 
       if integration_steps % points_per != 0:
          raise ValueError("Number of integration steps must be divisible by the number of points recorded between timesteps")
 
+      #number of time steps
       T = len(vlsvTObject.files)
    
       #number of seed points
@@ -564,13 +590,43 @@ class streaklines:
          t_0 = t_1
          
       #Back up return M 
+      
       return M #matrix of form shape = (N, T_eff, T_eff, 3)
 
 
-   def get_pathline(self):
-      pathline = np.array([])
+   def _time_to_idx(self, time):
+      """
+      From know dt, t range, and record_dt can determine 
+      for a given time the index in M  
+      """
+      if (time < self.time_range[0]) or (time> self.time_range[1]):
+         raise ValueError(f"Time not with the analyzed time range of {self.time_range[0]}-{self.time_range[1]}")
+      idx = None
+      return idx
+
+   def get_pathline(self, seed_idx, time):
+      """
+      Get the pathline of a seed point released at a given time (release idx)
+      TODO currently this assumes that you know the index of a random time
+      --> make time be a input --> return closest pathline  
+      """
+      release_idx = self._time_to_idx(time=time)
+      
+      pathline = self.M[seed_idx, :, release_idx, :]
+      
       return pathline
    
-   def get_streakline(self):
-      streakline = np.array([])
-      return streakline
+   def get_streakline(self, seed_idx, time):
+      """
+      Get the streakline between the start time and a given time (time_idx)
+      TODO currently this assumes that you know the index of a random time
+      --> make time be a input --> return closest streakline 
+      the last time is interesting so letting -1 be option
+      """
+      if time == -1:
+         time_idx = -1
+      else:
+         time_idx = self._time_to_idx(time=time)
+      streakline = self.M[seed_idx, time_idx, :, : ]
+
+      return streakline 

--- a/analysator/calculations/timeevolution.py
+++ b/analysator/calculations/timeevolution.py
@@ -296,7 +296,7 @@ class VlsvTInterpolator:
          self.activeReaders['low'] = self.readers[max(rti-1,0)]
 
       if self.activeReaders['hi']:
-         if lower_t == self.activeReaders['hi'].read_parameter('time'):
+         if upper_t == self.activeReaders['hi'].read_parameter('time'):
                pass
          else:
                self.activeReaders['hi'] = self.readers[min(rti,len(self.ts)-1)]


### PR DESCRIPTION
Added streaklines_3D function to fieldtracer that outputs a pathline/streakline matrix from seed points and a list of Vlsv files. The function outputs a (N, T, T, 3) matrix, where N is the number of seed points, T the number of time steps. Each seed gives a (i,j,3) matrix where the i-axis is the coordinate time, and j-axis is the release time of the particles. Each of the matrix cells stores a 3-D coordinate of the evolved seed point.  The diagonal gives the seed point/release point where particles are started to track. The locations of the seed points are recorded at each of the provided time steps. 
