### PR TITLE
Pinned python version for test_python_turso

### DIFF
--- a/.github/workflows/generate_reference_plots.yml
+++ b/.github/workflows/generate_reference_plots.yml
@@ -29,7 +29,7 @@ jobs:
             export UV_LINK_MODE=copy
             module purge
             module load Python/3.10.4-GCCcore-11.3.0
-            uv venv CI_env
+            uv venv --python=3.10.4 CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]
         - name: Produce plots

--- a/.github/workflows/test_compare_image_oldest_python.yml
+++ b/.github/workflows/test_compare_image_oldest_python.yml
@@ -49,6 +49,7 @@ jobs:
             done
             echo "::warning::Found $VERSIONS_MATCH"
             echo "PYTHON=$VERSIONS_MATCH" >> $GITHUB_OUTPUT
+            echo "PY_VERSION=$PYTHON" >> $GITHUB_OUTPUT
             module load $VERSIONS_MATCH
             module list Python
         - name: Install dependencies
@@ -59,7 +60,7 @@ jobs:
             module purge
             module load ${{ steps.pyversion.outputs.PYTHON }}
             module list
-            uv venv CI_env
+            uv venv --python=${{ steps.pyversion.outputs.PY_VERISON }} CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]
         - name: Produce plots

--- a/.github/workflows/test_compare_images.yml
+++ b/.github/workflows/test_compare_images.yml
@@ -37,7 +37,7 @@ jobs:
             export UV_LINK_MODE=copy
             module purge
             module load Python/3.10.4-GCCcore-11.3.0
-            uv venv CI_env
+            uv venv --python=3.10.4 CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]
         - name: Produce plots

--- a/.github/workflows/test_compare_images_full.yml
+++ b/.github/workflows/test_compare_images_full.yml
@@ -34,7 +34,7 @@ jobs:
             export UV_LINK_MODE=copy
             module purge
             module load Python/3.10.4-GCCcore-11.3.0
-            uv venv CI_env
+            uv venv --python=3.10.4 CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]
         - name: Produce plots

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -33,10 +33,8 @@ jobs:
             export TMPDIR=$RUNNER_TEMP
             export UV_LINK_MODE=copy
             module purge
-            module list
             module load Python/3.10.4-GCCcore-11.3.0
-            which python
-            uv venv CI_env
+            uv venv --python=3.10.4 CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]
         - name: Trial imports

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -31,6 +31,9 @@ jobs:
           timeout-minutes: 5
           run: |
             export TMPDIR=$RUNNER_TEMP
+            export UV_LINK_MODE=copy
+            module purge
+            module load Python/3.10.4-GCCcore-11.3.0
             uv venv CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]

--- a/.github/workflows/test_python_turso.yml
+++ b/.github/workflows/test_python_turso.yml
@@ -33,7 +33,9 @@ jobs:
             export TMPDIR=$RUNNER_TEMP
             export UV_LINK_MODE=copy
             module purge
+            module list
             module load Python/3.10.4-GCCcore-11.3.0
+            which python
             uv venv CI_env
             . CI_env/bin/activate
             uv pip install --editable ../analysator[${{ matrix.extras }}]


### PR DESCRIPTION
Despite using `module load Python/3.10.4` it seems **NOT** guarantee that the uv will actually use that python version, thus we now have forced uv to use the correct version with `--python=[version]` parameter.