### PR TITLE
better scancel in workflow

### DIFF
--- a/.github/workflows/make_sbatch_job.sh
+++ b/.github/workflows/make_sbatch_job.sh
@@ -7,8 +7,8 @@ fi
 #if sbatch fails as it gets the error code from python it tries to print the log 
 #   first with srun (in case the file has not yet updated on the front end)
 #   second if srun fails (in case communication failure) it tries to cat it on the frontend (may be empty if file has not been updated pyproject)
-
-sbatch -W --array=1-$ARRAY_SIZE -o "$1" ./testpackage/$1.sh $2 > jobid_$1 || true
+export "TP_PID=$$" >> $GITHUB_OUTPUT
+sbatch -W --array=1-$ARRAY_SIZE -o "$1" -J "CI_$$" ./testpackage/$1.sh $2 > jobid_$1 || true
 
 #in case we do exit 0 successfully
 LOG=$(srun cat $1 || cat $1)

--- a/.github/workflows/test_compare_images.yml
+++ b/.github/workflows/test_compare_images.yml
@@ -132,6 +132,7 @@ jobs:
         - name: scancel dangling job upon cancellation
           if: cancelled()
           run: |
+            scancel -n "TP_${{ steps.run_cl.outputs.TP_PID }}" --user $(whoami) 
             scancel ${{ steps.run_cl.outputs.SLURM_JOB_ID }}
             
   


### PR DESCRIPTION
Added scancel based on job name using the PID in the case the workflow gets cancelled while the sbatch job is in queue (in such a case the slurm job id will not have been saved yet