### PR TITLE
Vlsvrs import rename for backend PR

### DIFF
--- a/analysator/vlsvfile/vlsvreader.py
+++ b/analysator/vlsvfile/vlsvreader.py
@@ -31,7 +31,7 @@ import sys
 import re
 import numbers
 try:
-   import vlsvrs
+   from analysator_backends import vlsvrs
    HAS_VLSVRS = True
 except ImportError:
    HAS_VLSVRS = False

--- a/testpackage/testpackage_hashes.py
+++ b/testpackage/testpackage_hashes.py
@@ -1,6 +1,6 @@
 import analysator as pt
 import numpy as np
-import vlsvrs
+from analysator_backends import vlsvrs
 import os
 import hashlib
 import pickle


### PR DESCRIPTION
This should be merged after https://version.helsinki.fi/vlasiator/analysator-backends/-/merge_requests/16 has been merged to the backend. This is due to the changing of the backend module structure to be that vlsvrs is found under `from analysator_backends import vlsvrs`