### PR TITLE
Removing loop from build_dual_from_vertices

### DIFF
--- a/analysator/vlsvfile/vlsvreader.py
+++ b/analysator/vlsvfile/vlsvreader.py
@@ -3387,7 +3387,6 @@ class VlsvReader(object):
       return cell_neighbor_sets
 
 
-
    def build_dual_from_vertices(self, vertices):
 
       vertices = list(set(vertices))
@@ -3418,19 +3417,20 @@ class VlsvReader(object):
          eps = 1
          v_cells = np.zeros((len_todo, 8),dtype=int)
          v_cellcoords = np.zeros((len_todo, 8,3))
-         ii = 0
          vcoords = self.get_vertex_coordinates_from_indices(todo)
 
-         # TODO get rid of the loop
-         offsets = []
-         for x in [-1,1]:
-            for y in [-1,1]:
-               for z  in [-1,1]:
-                  offsets.append([x,y,z])
-                  v_cellcoords[:,ii,:] = eps*np.array((x,y,z))[np.newaxis,:] + vcoords
-                  v_cells[:,ii] = self.get_cellid(v_cellcoords[:,ii])
-                  ii += 1
-
+         offsets=np.array([
+                     [-1.,-1.,-1.],
+                     [-1.,-1.,1.],
+                     [-1.,1.,-1.],
+                     [-1.,1.,1.],
+                     [1.,-1.,-1.],
+                     [1.,-1.,1.],
+                     [1.,1.,-1.],
+                     [1.,1.,1.],
+                 ])
+         v_cellcoords=np.swapaxes(vcoords+eps*offsets[:,np.newaxis],0,1) 
+         v_cells=self.get_cellid(v_cellcoords)
          v_cellcoords = self.get_cell_coordinates(v_cells.reshape((-1))).reshape((-1,8,3))
 
          dual_sets.update({vinds: tuple(v_cells[i,:]) for i,vinds in enumerate(todo)})

--- a/analysator/vlsvfile/vlsvreader.py
+++ b/analysator/vlsvfile/vlsvreader.py
@@ -3430,7 +3430,7 @@ class VlsvReader(object):
                      [1.,1.,1.],
                  ])
          v_cellcoords=np.swapaxes(vcoords+eps*offsets[:,np.newaxis],0,1) 
-         v_cells=self.get_cellid(v_cellcoords)
+         v_cells=self.get_cellid(v_cellcoords.reshape((-1,3))).reshape((-1,8))
          v_cellcoords = self.get_cell_coordinates(v_cells.reshape((-1))).reshape((-1,8,3))
 
          dual_sets.update({vinds: tuple(v_cells[i,:]) for i,vinds in enumerate(todo)})


### PR DESCRIPTION
Found a trick to remove the loop sort of by accident. it does make it slightly faster. 

For example for 

```
    f = pt.vlsvfile.VlsvReader(name)
    x, y, z = np.meshgrid(
        np.linspace(0, 16, 100000), np.linspace(0, 2, 20), np.linspace(0, 2, 20)
    )
    x = dx * x * np.random.random()
    y = dx * y * np.random.random()
    z = dx * z * np.random.random()

    coor = np.vstack([x.ravel(), y.ravel(), z.ravel()]).T
    cell_vertex_sets = f.get_cell_corner_vertices(
        coorpy
    )  # these are enough to fetch the neighbours
    cell_neighbor_sets = {c: set() for c in cell_vertex_sets.keys()}
    vertices_todo = set().union(*cell_vertex_sets.values())
    
    # print(coor)
    t0 = time.time()
    arr1 = f.build_dual_from_vertices(vertices_todo)
    # print("python arr",arr)
    t1 = time.time() - t0
    f = pt.vlsvfile.VlsvReader(name)
    t0 = time.time()
    arr2 = f.build_dual_from_vertices_new(vertices_todo)
    t2 = time.time() - t0
```
Over ten runs gives me speed up of t1/t2 with mean t1 and t2 as 
```
means 1.5215530983190788 old avg 0.010848474502563477 new avg 0.007144737243652344
```
also checked that the bboxes it produces and the output remain the same
